### PR TITLE
Introduce tutorial 6 for using the Mesa backend

### DIFF
--- a/agentMET4FOF/dashboard/Dashboard.py
+++ b/agentMET4FOF/dashboard/Dashboard.py
@@ -180,5 +180,9 @@ class AgentDashboardThread(AgentDashboard, Thread):
 
     def terminate(self):
         """This is shutting down the application server serving the web interface"""
-        self._server.shutdown()
+        try:
+            self._server.shutdown()
+        except AttributeError:
+            # In this case the dashboard has in fact already been shutdown earlier.
+            pass
         self._supposed_to_run = False

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -1,6 +1,4 @@
-import sys
 import warnings
-from collections import Iterable
 
 import dash
 import dash_core_components as dcc
@@ -9,14 +7,15 @@ import dash_html_components as html
 import networkx as nx
 from dash.dependencies import ClientsideFunction
 from dash.exceptions import PreventUpdate
-from time_series_metadata.scheme import MetaData
 
 from . import LayoutHelper
-from .LayoutHelper import create_edges_cytoscape, create_monitor_graph, \
-    create_nodes_cytoscape
-from .. import agents as agentmet4fof_module
-
 from .Dashboard_layout_base import Dashboard_Layout_Base
+from .LayoutHelper import (
+    create_edges_cytoscape,
+    create_monitor_graph,
+    create_nodes_cytoscape,
+)
+from .. import agents as agentmet4fof_module
 
 
 class Dashboard_agt_net(Dashboard_Layout_Base):

--- a/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
+++ b/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
@@ -1,18 +1,14 @@
 from agentMET4FOF.agents import AgentNetwork, MonitorAgent, SineGeneratorAgent
 
 
-def demonstrate_metrological_stream():
+def demonstrate_mesa_backend():
 
-    # start agent network server
-    _agent_network = AgentNetwork(dashboard_modules=True, backend="mesa")
+    # Start agent network and specify backend via the corresponding keyword parameter.
+    _agent_network = AgentNetwork(backend="mesa")
 
-    # Initialize metrologically enabled agent taking name from signal source metadata.
+    # Initialize agents by adding them to the agent network.
     sine_agent = _agent_network.add_agent(agentType=SineGeneratorAgent)
-
-    # Initialize metrologically enabled plotting agent.
     monitor_agent = _agent_network.add_agent(agentType=MonitorAgent, buffer_size=200)
-
-    # Bind agents.
     sine_agent.bind_output(monitor_agent)
 
     # Set all agents states to "Running".
@@ -22,4 +18,4 @@ def demonstrate_metrological_stream():
 
 
 if __name__ == "__main__":
-    demonstrate_metrological_stream()
+    demonstrate_mesa_backend()

--- a/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
+++ b/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
@@ -1,3 +1,10 @@
+# By default, "osbrain" backend offers real connectivity between agents (each agent has its own port & IP address) in distributed systems (e,g connecting agents from raspberry pis to PCs, etc),
+# which explains why it is harder to debug.
+# In the "mesa" backend, there's only one real timer which is started in the AgentNetwork, and every timer tick will advance the agent actions by calling `step()` which includes `agent_loop` and `on_received_message`.
+# Moreover, in the "mesa" backend, agents do not have their own port and IP addresses, they are simulated objects to emulate the behaviour of distributed agents.
+# Hence, "osbrain" is closer to deployment phase, whereas mesa is suited for the simulation/designing phase.
+# To switch between the backends, simply pass the backend parameter to either "mesa" or "osbrain" in the AgentNetwork instantiation.
+
 from agentMET4FOF.agents import AgentNetwork, MonitorAgent, SineGeneratorAgent
 
 

--- a/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
+++ b/agentMET4FOF_tutorials/tutorial_6_mesa_backend.py
@@ -1,0 +1,25 @@
+from agentMET4FOF.agents import AgentNetwork, MonitorAgent, SineGeneratorAgent
+
+
+def demonstrate_metrological_stream():
+
+    # start agent network server
+    _agent_network = AgentNetwork(dashboard_modules=True, backend="mesa")
+
+    # Initialize metrologically enabled agent taking name from signal source metadata.
+    sine_agent = _agent_network.add_agent(agentType=SineGeneratorAgent)
+
+    # Initialize metrologically enabled plotting agent.
+    monitor_agent = _agent_network.add_agent(agentType=MonitorAgent, buffer_size=200)
+
+    # Bind agents.
+    sine_agent.bind_output(monitor_agent)
+
+    # Set all agents states to "Running".
+    _agent_network.set_running_state()
+
+    return _agent_network
+
+
+if __name__ == "__main__":
+    demonstrate_metrological_stream()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,12 +1,11 @@
 import pytest
-from flask import request
 
 from agentMET4FOF.agents import AgentNetwork
 from tests.conftest import test_timeout
 
 
 @pytest.mark.timeout(test_timeout)
-@pytest.mark.parametrize("backend", ["osbrain"])
+@pytest.mark.parametrize("backend", ["mesa", "osbrain"])
 def test_shutdown(backend):
     # Check if the agent network gets properly setup and stopped again. The tear down
     # does not terminate cleanly for the "Mesa" backend yet, so we only test "osbrain".

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -9,28 +9,36 @@ from agentMET4FOF_tutorials.tutorial_4_metrological_streams import (
 from agentMET4FOF_tutorials.tutorial_5_coalition import (
     demonstrate_generator_agent_use as tut5,
 )
+from agentMET4FOF_tutorials.tutorial_6_mesa_backend import (
+    demonstrate_mesa_backend as tut6,
+)
 
 
 def test_tutorial_1():
-    # Test executability of tutorial_1_generator_agent.
+    """Test executability of tutorial_1_generator_agent."""
     tut1().shutdown()
 
 
 def test_tutorial_2():
-    # Test executability of tutorial_2_math_agent.
+    """Test executability of tutorial_2_math_agent."""
     tut2().shutdown()
 
 
 def test_tutorial_3():
-    # Test executability of tutorial_3_multi_channel.
+    """Test executability of tutorial_3_multi_channel."""
     tut3().shutdown()
 
 
 def test_tutorial_4():
-    # Test executability of tutorial_4_metrological_streams.py.
+    """Test executability of tutorial_4_metrological_streams.py."""
     tut4().shutdown()
 
 
 def test_tutorial_5():
-    # Test executability of tutorial_5_coalition.py.
+    """Test executability of tutorial_5_coalition.py."""
     tut5().shutdown()
+
+
+def test_tutorial_6():
+    """Test executability of tutorial_6_mesa_backend.py."""
+    tut6().shutdown()

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -14,6 +14,11 @@ from agentMET4FOF_tutorials.tutorial_6_mesa_backend import (
 )
 
 
+def test_tutorial_6():
+    """Test executability of tutorial_6_mesa_backend.py."""
+    tut6().shutdown()
+
+
 def test_tutorial_1():
     """Test executability of tutorial_1_generator_agent."""
     tut1().shutdown()
@@ -37,8 +42,3 @@ def test_tutorial_4():
 def test_tutorial_5():
     """Test executability of tutorial_5_coalition.py."""
     tut5().shutdown()
-
-
-def test_tutorial_6():
-    """Test executability of tutorial_6_mesa_backend.py."""
-    tut6().shutdown()


### PR DESCRIPTION
This is based on the assumption we will at some point merge the transfer of tutorial agents into develop. If we do not merge it, then we just build upon any other existing tutorial for the mesa backend.

This resolves #167 