### PR TITLE
introduce noise to the tutorial of buffering moving average

### DIFF
--- a/agentMET4FOF_tutorials/buffering/moving_average.py
+++ b/agentMET4FOF_tutorials/buffering/moving_average.py
@@ -6,9 +6,8 @@
 from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
 from agentMET4FOF.streams import SineGenerator
 import numpy as np
-import plotly.graph_objs as go
 
-class SineGeneratorAgent(AgentMET4FOF):
+class NoisySineGeneratorAgent(AgentMET4FOF):
     """An agent streaming a sine signal
 
     Takes samples from the :py:mod:`SineGenerator` and pushes them sample by sample
@@ -34,7 +33,8 @@ class SineGeneratorAgent(AgentMET4FOF):
         """
         if self.current_state == "Running":
             sine_data = self._sine_stream.next_sample()  # dictionary
-            self.send_output(sine_data)
+            sine_data["quantities"] = sine_data["quantities"] + np.random.rand(*sine_data["quantities"].shape)
+            self.send_output(sine_data["quantities"])
 
 class RollingMeanAgent(AgentMET4FOF):
     """
@@ -64,7 +64,7 @@ def demonstrate_generator_agent_use():
     agent_network = AgentNetwork()
 
     # Initialize agents by adding them to the agent network.
-    gen_agent = agent_network.add_agent(agentType=SineGeneratorAgent)
+    gen_agent = agent_network.add_agent(agentType=NoisySineGeneratorAgent)
     fast_rolling_mean_agent = agent_network.add_agent(agentType=RollingMeanAgent, buffer_size=5)
     slow_rolling_mean_agent = agent_network.add_agent(agentType=RollingMeanAgent, buffer_size=10)
 


### PR DESCRIPTION
- I must have missed out this commit which i was supposed to make earlier, importantly, this aligns with the video tutorial content
- of course, more elegantly could use the metrological sine stream with noise which was introduced in this branch.
- Edit: found the commit here : https://github.com/Met4FoF/agentMET4FOF/commit/25277de757d72105d5ab1b24bc0f1d913a0dca72 which was not merged yet in another branch..