### PR TITLE
Introduce psutil into dependencies and recompile dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,7 @@ commands:
         name: Run tests
         command: |
           source venv/bin/activate
-          pytest -v --junitxml=test-reports/pytest.xml --cov=. . | tee \
-              test-reports/agentMET4FOF.log
+          tox | tee --append test-reports/agentMET4FOF.log
 
     # Upload coverage report if the according parameter is set to `true`.
     - when:
@@ -160,7 +159,7 @@ jobs:
           command: |
             source $HOME/conda/etc/profile.d/conda.sh
             conda activate agentMET4FOF
-            pytest -v --junitxml=test-reports/junit.xml . | tee test-reports/pytest.log
+            tox | tee --append test-reports/agentMET4FOF.log
 
       - store_test_artifacts_and_results
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ exclude_lines =
 ignore_errors = True
 omit =
     *venv/*
+    .tox/*
     tests/*
     docs/*
     setup.py

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,3 +1,5 @@
+-c requirements.txt
+
 pytest
 pytest-cov
 pytest-timeout

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,3 +10,4 @@ nbsphinx
 recommonmark
 sphinx_rtd_theme
 ipython
+tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,8 @@
 #
 alabaster==0.7.12
     # via sphinx
+appdirs==1.4.4
+    # via virtualenv
 async-generator==1.10
     # via nbclient
 attrs==20.3.0
@@ -19,17 +21,25 @@ backcall==0.2.0
 bleach==3.3.0
     # via nbconvert
 certifi==2020.12.5
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 chardet==4.0.0
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 commonmark==0.9.1
     # via recommonmark
 coverage==5.4
     # via pytest-cov
 decorator==4.4.2
-    # via ipython
+    # via
+    #   -c requirements.txt
+    #   ipython
 defusedxml==0.6.0
     # via nbconvert
+distlib==0.3.1
+    # via virtualenv
 docutils==0.16
     # via
     #   nbsphinx
@@ -37,8 +47,14 @@ docutils==0.16
     #   sphinx
 entrypoints==0.3
     # via nbconvert
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
 idna==2.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 imagesize==1.2.0
     # via sphinx
 iniconfig==1.1.1
@@ -53,6 +69,7 @@ jedi==0.18.0
     # via ipython
 jinja2==2.11.3
     # via
+    #   -c requirements.txt
     #   nbconvert
     #   nbsphinx
     #   sphinx
@@ -68,7 +85,9 @@ jupyter-core==4.7.1
 jupyterlab-pygments==0.1.2
     # via nbconvert
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 mistune==0.8.4
     # via nbconvert
 nbclient==0.5.1
@@ -89,6 +108,7 @@ packaging==20.9
     #   bleach
     #   pytest
     #   sphinx
+    #   tox
 pandocfilters==1.4.3
     # via nbconvert
 parso==0.8.1
@@ -98,15 +118,21 @@ pexpect==4.8.0
 pickleshare==0.7.5
     # via ipython
 pluggy==0.13.1
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 prompt-toolkit==3.0.14
     # via ipython
 psutil==5.8.0
-    # via -r dev-requirements.in
+    # via
+    #   -c requirements.txt
+    #   -r dev-requirements.in
 ptyprocess==0.7.0
     # via pexpect
 py==1.10.0
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 pygments==2.7.4
     # via
     #   ipython
@@ -114,7 +140,9 @@ pygments==2.7.4
     #   nbconvert
     #   sphinx
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   -c requirements.txt
+    #   packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-cov==2.11.1
@@ -127,22 +155,32 @@ pytest==6.2.2
     #   pytest-cov
     #   pytest-timeout
 python-dateutil==2.8.1
-    # via jupyter-client
+    # via
+    #   -c requirements.txt
+    #   jupyter-client
 pytz==2021.1
-    # via babel
+    # via
+    #   -c requirements.txt
+    #   babel
 pyzmq==22.0.2
-    # via jupyter-client
+    # via
+    #   -c requirements.txt
+    #   jupyter-client
 recommonmark==0.7.1
     # via -r dev-requirements.in
 requests==2.25.1
     # via
+    #   -c requirements.txt
     #   -r dev-requirements.in
     #   sphinx
 six==1.15.0
     # via
+    #   -c requirements.txt
     #   bleach
     #   jsonschema
     #   python-dateutil
+    #   tox
+    #   virtualenv
 snowballstemmer==2.1.0
     # via sphinx
 sphinx-rtd-theme==0.5.1
@@ -168,9 +206,15 @@ sphinxcontrib-serializinghtml==1.1.4
 testpath==0.4.4
     # via nbconvert
 toml==0.10.2
-    # via pytest
+    # via
+    #   pytest
+    #   tox
 tornado==6.1
-    # via jupyter-client
+    # via
+    #   -c requirements.txt
+    #   jupyter-client
+tox==3.21.4
+    # via -r dev-requirements.in
 traitlets==5.0.5
     # via
     #   ipython
@@ -181,7 +225,11 @@ traitlets==5.0.5
     #   nbformat
     #   nbsphinx
 urllib3==1.26.3
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
+virtualenv==20.4.2
+    # via tox
 wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ networkx==2.5
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
-numpy==1.20.0
+numpy==1.20.1
     # via
     #   agentMET4FOF (setup.py)
     #   matplotlib
@@ -95,7 +95,7 @@ numpy==1.20.0
     #   time-series-buffer
 osbrain==0.6.5
     # via agentMET4FOF (setup.py)
-pandas==1.2.1
+pandas==1.2.2
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
@@ -105,6 +105,8 @@ plotly==4.14.3
     #   dash
 poyo==0.5.0
     # via cookiecutter
+psutil==5.8.0
+    # via agentMET4FOF (setup.py)
 pyparsing==2.4.7
     # via matplotlib
 pyro4==4.80

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/bangxiangyong/agentMET4FOF",
     author=u"Bang Xiang Yong, Björn Ludwig, Anupam Prasad Vedurmudi, "
-           u"Maximilian Gruber, Haris Lulic",
+    u"Maximilian Gruber, Haris Lulic",
     author_email="bxy20@cam.ac.uk",
     keywords="uncertainty metrology MAS agent-based agents",
     packages=find_packages(exclude=["tests"]),
@@ -76,6 +76,7 @@ setup(
         "time-series-metadata",
         "mpld3",
         "mesa",
+        "psutil",
     ],
     extras_require={"tutorials": ["notebook", "PyDynamic"]},
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "psutil",
     ],
     extras_require={"tutorials": ["notebook", "PyDynamic"]},
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ skip_missing_interpreters=true
 deps =
     -rdev-requirements.txt
 # Run those tests in our virtual environments.
-commands = pytest -v --cov=agentMET4FOF/ --junitxml=test-reports/junit.xml
+commands = pytest -v --cov=. --junitxml=test-reports/junit.xml .

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# tox.ini configures the shared testing routine and specifies what Python
+# versions are meant to be tested.
+[tox]
+envlist = py38
+skipsdist = false
+skip_missing_interpreters=true
+
+[testenv]
+# Specify dependencies that we want tox to install for us.
+deps =
+    -rrequirements.txt
+    -rdev-requirements.txt
+# Run those tests in our virtual environments.
+commands = pytest -v --cov=agentMET4FOF/ --junitxml=test-reports/junit.xml


### PR DESCRIPTION
Release 0.5.0 unfortunately does not contain one of the introduced dependencies in the _setup.py_ and thus not the _requirements.txt_ but only in the _dev-requirements_, which was sufficient until 0.4.1 but not anymore. We introduce the needed `psutil` as a bugfix.