### PR TITLE
Enhance subscribe and channels 

### DIFF
--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -532,6 +532,7 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
         if hasattr(self, method_name):
             self.get_attr(method_name)(**data_params)
 
+    def on_connect_output(self, output_agent):
         """
         This user provided method is called whenever an agent is connected to its output.
 
@@ -600,6 +601,9 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
             # update channels subscription information for mesa
             else:
                 self.Outputs_agent_channels.update({output_agent.get_attr('name'): channel})
+
+            # calls on connect output method
+            self.on_connect_output(output_agent)
 
             # LOGGING
             if self.log_mode:

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -417,7 +417,8 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
         """
         if channel not in self.output_channels_info.keys():
             if type(data) == dict:
-                nested_metadata = {key: self._get_metadata(data[key]) for key in data.keys()}
+                nested_metadata = {key: {nested_dict_key:self._get_metadata(nested_dict_val) for nested_dict_key,nested_dict_val in data[key].items()}
+                if isinstance(data[key],dict) else self._get_metadata(data[key]) for key in data.keys()}
                 self.output_channels_info.update({channel: nested_metadata})
             else:
                 self.output_channels_info.update({channel: self._get_metadata(data)})

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -917,7 +917,7 @@ class _AgentController(AgentMET4FOF):
     Provides global control to all agents in network.
     """
 
-    def init_parameters(self, ns=None, backend='osbrain', mesa_model=""):
+    def init_parameters(self, ns=None, backend='osbrain', mesa_model="", log_mode=True):
         self.backend = backend
         self.states = {0: "Idle", 1: "Running", 2: "Pause", 3: "Stop"}
         self.current_state = "Idle"
@@ -925,6 +925,7 @@ class _AgentController(AgentMET4FOF):
         self.G = nx.DiGraph()
         self._logger = None
         self.coalitions = []
+        self.log_mode = log_mode
 
         if backend == "mesa":
             self.mesa_model = mesa_model

--- a/agentMET4FOF/dashboard/Dashboard.py
+++ b/agentMET4FOF/dashboard/Dashboard.py
@@ -8,7 +8,6 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 import psutil
-
 from .Dashboard_Control import _Dashboard_Control
 import pathos
 
@@ -22,7 +21,7 @@ class AgentDashboard:
     def __init__(self, dashboard_modules=[], dashboard_layouts=[],
                  dashboard_update_interval = 3, max_monitors=10, ip_addr="127.0.0.1",
                  port=8050, agentNetwork="127.0.0.1", agent_ip_addr=3333,
-                 agent_port=None):
+                 agent_port=None, network_stylesheet=[], hide_default_edge=True, **kwargs):
         """
         Parameters
         ----------
@@ -64,7 +63,7 @@ class AgentDashboard:
                 self.external_stylesheets = ['https://fonts.googleapis.com/icon?family=Material+Icons', 'https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css']
                 self.external_scripts = ['https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js']
                 self.app = self.init_app_layout(
-                    update_interval_seconds=dashboard_update_interval,max_monitors=max_monitors, dashboard_layouts=dashboard_layouts)
+                    update_interval_seconds=dashboard_update_interval,max_monitors=max_monitors, dashboard_layouts=dashboard_layouts, network_stylesheet=network_stylesheet, hide_default_edge=hide_default_edge, **kwargs)
                 self.app.dashboard_ctrl = _Dashboard_Control(modules=dashboard_modules,agent_ip_addr=agent_ip_addr,agent_port=agent_port,agentNetwork=agentNetwork)
                 # Spawn a very simple WSGI server.
                 self._server = make_server(host=self.ip_addr, port=self.port, app=self.app.server)
@@ -89,7 +88,9 @@ class AgentDashboard:
             )
             self._server.serve_forever()
 
-    def init_app_layout(self,update_interval_seconds=3, max_monitors=10, dashboard_layouts=[]):
+    def init_app_layout(self,update_interval_seconds=3, max_monitors=10,
+                        dashboard_layouts=[],
+                        network_stylesheet=[], hide_default_edge=True, **kwargs):
         """
         Initialises the overall dash app "layout" which has two sub-pages (Agent network and ML experiment)
 
@@ -110,8 +111,13 @@ class AgentDashboard:
                         external_stylesheets=self.external_stylesheets,
                         external_scripts=self.external_scripts
                         )
+        app.network_stylesheet = network_stylesheet
         app.update_interval_seconds = update_interval_seconds
         app.num_monitors = max_monitors
+        app.hide_default_edge = hide_default_edge
+
+        for key in kwargs.keys():
+            setattr(app,key,kwargs[key])
 
         #initialise dashboard layout objects
         self.dashboard_layouts = [dashboard_layout(app) for dashboard_layout in dashboard_layouts]
@@ -181,7 +187,8 @@ class AgentDashboardThread(AgentDashboard, Thread):
             port=8050,
             agentNetwork="127.0.0.1",
             agent_ip_addr=3333,
-            agent_port=None
+            agent_port=None,
+            **kwargs
     ):
         super(AgentDashboardThread, self).__init__(
             dashboard_modules=dashboard_modules,
@@ -192,7 +199,8 @@ class AgentDashboardThread(AgentDashboard, Thread):
             port=port,
             agentNetwork=agentNetwork,
             agent_ip_addr=agent_ip_addr,
-            agent_port=agent_port
+            agent_port=agent_port,
+            **kwargs
         )
         # Make sure, we are actually able to stop the server running from outside by
         # calling terminate() later.

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -361,7 +361,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             if agentNetwork.get_mode() != "Running" and agentNetwork.get_mode() != "Reset" and n_interval > 0:
                 raise PreventUpdate
 
-            agent_names = agentNetwork.agents('MonitorAgent')  # get all agent names
+            agent_names = agentNetwork.agents(filter_agent='Monitor')  # get all agent names
             app.num_monitor = len(agent_names)
             monitor_graphs = [{'data': []} for i in range(app.num_monitors)]
             style_graphs = [{'opacity': 0, 'width': 10, 'height': 10} for i in range(app.num_monitors)]

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -502,16 +502,16 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             if agentNetwork.get_mode() != "Running" and n_interval > 0:
                 raise PreventUpdate
 
-            agent_names = agentNetwork.agents()  # get all agent names
-            agent_type = "Monitor"  # all agents with Monitor in its name will be selected
+            agent_type = "Monitor"
+            agent_names = agentNetwork.agents(filter_agent=agent_type)  # get all agent names
+              # all agents with Monitor in its name will be selected
             plots_data = {}  # storage for all monitor agent's memory
 
             # load data from all Monitor agent's memory
             for agent_name in agent_names:
-                if agent_type in agent_name:
-                    monitor_agent = agentNetwork.get_agent(agent_name)
-                    plots = monitor_agent.get_attr('plots')
-                    plots_data.update({agent_name: plots})
+                monitor_agent = agentNetwork.get_agent(agent_name)
+                plots = monitor_agent.get_attr('plots')
+                plots_data.update({agent_name: plots})
 
             # now monitors_data = {'monitor_agent1_name':agent1_memory, 'monitor_agent2_name':agent2_memory }
             # now create a plot for each monitor agent

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -27,7 +27,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
         return [dcc.Graph(id='monitors-graph-' + str(i), figure={}, style={'height': '90vh'}) for i in
                 range(num_monitors)]
 
-    def get_layout(self, update_interval_seconds=3, num_monitors=10):
+    def get_layout(self):
         # body
         return html.Div(className="row", children=[
 
@@ -57,57 +57,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                             layout={'name': 'breadthfirst'},
                             style={'width': '100%', 'height': '600px'},
                             elements=[],
-                            stylesheet=[
-                                {'selector': 'node', 'style':
-                                    {'label': 'data(id)',
-                                     'shape': 'rectangle'}
-                                 },
-                                {'selector': 'edge',
-                                 'style': {'curve-style': 'bezier', 'mid-target-arrow-shape':
-                                     'triangle', 'arrow-scale': 2, 'line-color': '#4287f5',
-                                           'mid-target-arrow-color': '#4287f5'},
-                                 },
-                                {
-                                    'selector': '.rectangle',
-                                    'style': {
-                                        'shape': 'rectangle'
-                                    }
-                                },
-                                {
-                                    'selector': '.triangle',
-                                    'style': {
-                                        'shape': 'triangle'
-                                    }
-                                },
-                                {
-                                    'selector': '.octagon',
-                                    'style': {
-                                        'shape': 'octagon'
-                                    }
-                                },
-                                {
-                                    'selector': '.ellipse',
-                                    'style': {
-                                        'shape': 'ellipse'
-                                    }
-                                },
-                                {
-                                    'selector': '.bluebackground',
-                                    'style': {
-                                        'background-color': '#c4fdff'
-                                    }
-                                },
-                                {
-                                    'selector': '.blue',
-                                    'style': {
-                                        'background-color': '#006db5'
-                                    }
-                                },
-                                {
-                                    'selector': '.coalition',
-                                    'style': {'line-style': 'dashed'}
-                                },
-                            ]
+                            stylesheet=self.app.network_stylesheet
 
                         )
 
@@ -116,7 +66,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                 ]),
                 html.H5(className="card", id="matplotlib-division", children=" "),
                 html.Div(className="card", id="monitors-temp-division",
-                         children=self.get_multiple_graphs(num_monitors)),
+                         children=self.get_multiple_graphs(self.app.num_monitors)),
 
             ]),
 
@@ -175,7 +125,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             ]),
             dcc.Interval(
                 id='interval-component-network-graph',
-                interval=update_interval_seconds * 1000,  # in milliseconds
+                interval=self.app.update_interval_seconds * 1000,  # in milliseconds
                 n_intervals=0
             ),
             dcc.Interval(
@@ -185,7 +135,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             ),
             dcc.Interval(
                 id='interval-update-monitor-graph',
-                interval=update_interval_seconds * 1000,  # in milliseconds
+                interval=self.app.update_interval_seconds * 1000,  # in milliseconds
                 n_intervals=0
             )
         ])
@@ -216,7 +166,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                 new_G.add_edges_from(edges)
 
                 nodes_elements = create_nodes_cytoscape(new_G)
-                edges_elements = create_edges_cytoscape(edges)
+                edges_elements = create_edges_cytoscape(edges, app.hide_default_edge)
                 # print(edges_elements)
                 # draw coalition nodes, and assign child nodes to coalition nodes
                 if len(agentNetwork.coalitions) > 0:

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -451,7 +451,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
 
                 # Check if any metadata is present that can be used to generate axis
                 # labels or otherwise use default labels.
-                if (
+                if (len(memory_data) > 0 and
                     isinstance(memory_data[sender_agent], dict)
                     and "metadata" in memory_data[sender_agent].keys()
                 ):

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -55,9 +55,9 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                         cyto.Cytoscape(
                             id='agents-network',
                             layout={'name': 'breadthfirst'},
-                            style={'width': '100%', 'height': '600px'},
+                            style={'width': '100%', 'height': '800px'},
                             elements=[],
-                            stylesheet=self.app.network_stylesheet
+                            stylesheet=self.app.network_stylesheet,
 
                         )
 
@@ -171,7 +171,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                 # draw coalition nodes, and assign child nodes to coalition nodes
                 if len(agentNetwork.coalitions) > 0:
                     parent_elements = [{"data": {'id': coalition.name, 'label': coalition.name},
-                                        'classes': 'bluebackground'} for coalition in agentNetwork.coalitions]
+                                        'classes': 'coalition'} for coalition in agentNetwork.coalitions]
                     for coalition in coalitions:
                         # check if agent is in the coalition, set its parents
                         for agent_node in nodes_elements:
@@ -182,7 +182,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                         for edges in edges_elements:
                             if edges["data"]["source"] in coalition.agent_names() and edges["data"][
                                 "target"] in coalition.agent_names():
-                                edges.update({'classes': "coalition"})
+                                edges.update({'classes': "coalition-edge"})
                 else:
                     parent_elements = []
 

--- a/agentMET4FOF/dashboard/LayoutHelper.py
+++ b/agentMET4FOF/dashboard/LayoutHelper.py
@@ -22,10 +22,13 @@ def create_nodes_cytoscape(agent_graph):
 
     return new_elements
 
-def create_edges_cytoscape(edges):
+def create_edges_cytoscape(edges, hide_default_edge=True):
     new_elements =[]
     for edge in edges:
-        new_elements += [{'data': {'source': edge[0], 'target': edge[1]}}]
+        if hide_default_edge and isinstance(edge[2]['channel'], str) and edge[2]['channel'] == "default":
+            new_elements += [{'data': {'source': edge[0], 'target': edge[1]}}]
+        else:
+            new_elements += [{'data': {'source': edge[0], 'target': edge[1], 'channel': edge[2]['channel']}}]
     return new_elements
 
 def create_monitor_graph(data,sender_agent = 'Monitor Agent'):

--- a/agentMET4FOF/dashboard/default_network_stylesheet.py
+++ b/agentMET4FOF/dashboard/default_network_stylesheet.py
@@ -1,0 +1,78 @@
+#For more information on all the available styles,
+#Please visit: https://dash.plotly.com/cytoscape/styling
+
+default_agent_network_stylesheet = [
+                                {'selector': 'node', 'style':
+                                    {'label': 'data(id)',
+                                     'shape': 'rectangle',
+                                         "text-valign": "center",
+                                         "text-halign": "center",
+                                         "color": "#FFF",
+                                         "text-outline-width": 1.5,
+                                         "text-outline-color":"#000232"
+                                     }
+                                 },
+                                {'selector': 'edge',
+                                 'style': {'curve-style': 'unbundled-bezier',
+                                           'mid-target-arrow-shape':
+                                               'triangle', 'arrow-scale': 2,
+                                           'line-color': '#4287f5',
+                                           'mid-target-arrow-color': '#4287f5',
+                                           'label': 'data(channel)',
+                                           "text-outline-width": 1.5,
+                                           "text-outline-color": "#000232",
+                                           "color": "#FFF",
+
+                                        "text-margin-x": "10px",
+                                        "text-margin-y": "20px"
+                                           },
+                                 },
+                                {
+                                    'selector': '.rectangle',
+                                    'style': {
+                                        'shape': 'rectangle'
+                                    }
+                                },
+                                {
+                                    'selector': '.triangle',
+                                    'style': {
+                                        'shape': 'triangle'
+                                    }
+                                },
+                                {
+                                    'selector': '.octagon',
+                                    'style': {
+                                        'shape': 'octagon'
+                                    }
+                                },
+                                {
+                                    'selector': '.ellipse',
+                                    'style': {
+                                        'shape': 'ellipse'
+                                    }
+                                },
+                                {
+                                    'selector': '.bluebackground',
+                                    'style': {
+                                        'background-color': '#c4fdff'
+                                    }
+                                },
+                                {
+                                    'selector': '.blue',
+                                    'style': {
+                                        'background-color': '#006db5'
+                                    }
+                                },
+                                {
+                                    'selector': '.coalition',
+                                    'style': {'line-style': 'dashed'}
+                                },
+                                {
+                                    "selector": ".outline",
+                                    "style": {
+                                        "color": "#fff",
+                                        "text-outline-color": "#888",
+                                        "text-outline-width": 2
+                                    }
+                                }
+                            ]

--- a/agentMET4FOF/dashboard/default_network_stylesheet.py
+++ b/agentMET4FOF/dashboard/default_network_stylesheet.py
@@ -65,6 +65,14 @@ default_agent_network_stylesheet = [
                                 },
                                 {
                                     'selector': '.coalition',
+                                    'style': {
+                                        'background-color': '#c4fdff',
+                                        "text-valign": "top",
+                                        "text-halign": "center",
+                                              }
+                                },
+                                {
+                                    'selector': '.coalition-edge',
                                     'style': {'line-style': 'dashed'}
                                 },
                                 {

--- a/agentMET4FOF_tutorials/plotting/basic_send_plot.py
+++ b/agentMET4FOF_tutorials/plotting/basic_send_plot.py
@@ -9,6 +9,9 @@
 #"plotly" mode will not work for all types of plot although it provides most interactivity
 #"mpld3" mode works for most plots, with medium interactivity
 
+#Update: To use `send_plot`, make sure you have connected the MonitorAgent to the "plot" channel of the
+#`input`/`source` agent
+
 from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
 import matplotlib.pyplot as plt
 import numpy as np
@@ -65,9 +68,9 @@ def main():
     agentNetwork.bind_agents(gen_agent, plotting_image_agent)
     agentNetwork.bind_agents(gen_agent, plotting_plotly_agent)
     agentNetwork.bind_agents(gen_agent, plotting_mpld3_agent)
-    agentNetwork.bind_agents(plotting_image_agent, monitor_agent)
-    agentNetwork.bind_agents(plotting_plotly_agent, monitor_agent)
-    agentNetwork.bind_agents(plotting_mpld3_agent, monitor_agent)
+    agentNetwork.bind_agents(plotting_image_agent, monitor_agent, channel="plot")
+    agentNetwork.bind_agents(plotting_plotly_agent, monitor_agent, channel="plot")
+    agentNetwork.bind_agents(plotting_mpld3_agent, monitor_agent, channel="plot")
 
     # set all agents states to "Running"
     agentNetwork.set_running_state()

--- a/agentMET4FOF_tutorials/tutorial_3_multi_channel.py
+++ b/agentMET4FOF_tutorials/tutorial_3_multi_channel.py
@@ -52,15 +52,17 @@ class MultiOutputMathAgent(AgentMET4FOF):
 def main():
     # start agent network server
     agentNetwork = AgentNetwork()
+
     # init agents
     gen_agent = agentNetwork.add_agent(agentType=MultiGeneratorAgent)
     multi_math_agent = agentNetwork.add_agent(agentType=MultiOutputMathAgent)
     monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
+
     # connect agents : We can connect multiple agents to any particular agent
     # However the agent needs to implement handling multiple inputs
-    agentNetwork.bind_agents(gen_agent, multi_math_agent)
-    agentNetwork.bind_agents(gen_agent, monitor_agent)
+    agentNetwork.bind_agents(gen_agent, multi_math_agent, channel=["sine","cosine"])
     agentNetwork.bind_agents(multi_math_agent, monitor_agent)
+
     # set all agents states to "Running"
     agentNetwork.set_running_state()
 

--- a/tests/test_send_plot_image.py
+++ b/tests/test_send_plot_image.py
@@ -44,7 +44,7 @@ def test_send_plot():
     gen_agent = agentNetwork.add_agent(agentType=GeneratorAgent)
     monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
 
-    agentNetwork.bind_agents(gen_agent, monitor_agent)
+    agentNetwork.bind_agents(gen_agent, monitor_agent, channel="plot")
 
     gen_agent.dummy_send_graph(mode="image")
     time.sleep(3)

--- a/tests/test_send_plot_plotly.py
+++ b/tests/test_send_plot_plotly.py
@@ -44,7 +44,7 @@ def test_send_plot():
     gen_agent = agentNetwork.add_agent(agentType=GeneratorAgent)
     monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
 
-    agentNetwork.bind_agents(gen_agent, monitor_agent)
+    agentNetwork.bind_agents(gen_agent, monitor_agent, channel="plot")
 
     gen_agent.dummy_send_graph(mode="plotly")
     time.sleep(3)


### PR DESCRIPTION
Previously, we had a pseudo-subscribe, that is information of the channel was provided in the message. 
But not an actual subscription to channel - the agents are still receiving messages from all channels but 'choose' not to handle them in the `on_received_message`. 

Now, clear separation of channels is implemented and receiving end will not receive unintended messages from channels they have not subscribed to.

UPDATE: Ability to display names of edges. This is possible with the information of specific channels defined in this pull RQ.
By default, "default" channel name is not displayed (see below), however this can be switched via:
`agentNetwork = AgentNetwork(hide_default_edge=False)`
![image](https://user-images.githubusercontent.com/8087472/108098611-7a4bac00-707b-11eb-9a2e-9ced96a9b712.png)

