### PR TITLE
Fix residing agent memory

### DIFF
--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1693,7 +1693,7 @@ class MonitorAgent(AgentMET4FOF):
         """
         Handles incoming data from 'default' and 'plot' channels.
 
-        Stores 'default' data into :attr:``self.buffer`` and 'plot' data into
+        Stores 'default' data into :attr:`buffer` and 'plot' data into
         :attr:``self.plots``
 
         Parameters

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1685,7 +1685,7 @@ class MonitorAgent(AgentMET4FOF):
             the :attr:`custom_plot_function`
         """
         self.plots = {}
-        self.plot_filter = [] if plot_filter is None else plot_filter
+        self.plot_filter = plot_filter
         self.custom_plot_function = custom_plot_function
         self.custom_plot_parameters = kwargs
 
@@ -1702,7 +1702,7 @@ class MonitorAgent(AgentMET4FOF):
             Acceptable channel values are 'default' or 'plot'
         """
         if message['channel'] == 'default':
-            if self.plot_filter != []:
+            if self.plot_filter:
                 message['data'] = {key: message['data'][key] for key in self.plot_filter}
             self.buffer_store(agent_from=message["from"], data=message["data"])
         elif message['channel'] == 'plot':

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1639,7 +1639,7 @@ class MonitorAgent(AgentMET4FOF):
     """
     Unique Agent for storing plots and data from messages received from input agents.
 
-    The dashboard searches for Monitor Agents' `memory` and `plots` to draw the graphs
+    The dashboard searches for Monitor Agents' `buffer` and `plots` to draw the graphs
     "plot" channel is used to receive base64 images from agents to plot on dashboard
 
     Attributes
@@ -1662,29 +1662,27 @@ class MonitorAgent(AgentMET4FOF):
 
     def init_parameters(
         self,
-        plot_filter: List[str] = None,
-        custom_plot_function: Callable[..., Scatter] = None,
-        *args,
+        plot_filter: Optional[List[str]] = None,
+        custom_plot_function: Optional[Callable[..., Scatter]] = None,
         **kwargs
     ):
         """Initialize the monitor agent's parameters
 
         Parameters
         ----------
-        plots : dict
-            Dictionary of format `{agent1_name : agent1_plot, agent2_name : agent2_plot}`
-        plot_filter : list of str
-            List of keys to filter the 'data' upon receiving message to be saved into memory
-            Used to specifically select only a few keys to be plotted
-        custom_plot_function : callable
+        plot_filter : list of str, optional
+            List of keys to filter the 'data' upon receiving message to be saved into
+            memory. Used to specifically select only a few keys to be plotted
+        custom_plot_function : callable, optional
             a custom plot function that can be provided to handle the data in the
             monitor agents buffer (see :class:`AgentMET4FOF` for details). The function
-            gets provided with the content (value) of the buffer and with the string of the
-            sender agent's name as stored in the buffer's keys. Additionally any other
-            parameters can be provided as a dict in custom_plot_parameters.
-        custom_plot_parameters : dict
-            a custom dictionary of parameters that shall be provided to each call of the
-            custom_plot_function
+            gets provided with the content (value) of the buffer and with the string of
+            the sender agent's name as stored in the buffer's keys. Additionally any
+            other parameters can be provided as a dict in custom_plot_parameters. By
+            default the data gets plotted as shown in the various tutorials.
+        kwargs : Any
+            custom key word parameters that shall be provided to each call of
+            the :attr:`custom_plot_function`
         """
         self.plots = {}
         self.plot_filter = [] if plot_filter is None else plot_filter

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1689,7 +1689,7 @@ class MonitorAgent(AgentMET4FOF):
             custom_plot_function
         """
         self.plots = {}
-        self.plot_filter = plot_filter
+        self.plot_filter = [] if plot_filter is None else plot_filter
         self.custom_plot_function = custom_plot_function
         self.custom_plot_parameters = kwargs
 

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -616,8 +616,19 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
 
     def get_all_attr(self):
         _all_attr = self.__dict__
-        excludes = ["Inputs", "Outputs", "memory", "PubAddr_alias", "PubAddr", "states", "log_mode", "get_all_attr",
-                    "plots", "name", "agent_loop"]
+        excludes = [
+            "Inputs",
+            "Outputs",
+            "buffer",
+            "PubAddr_alias",
+            "PubAddr",
+            "states",
+            "log_mode",
+            "get_all_attr",
+            "plots",
+            "name",
+            "agent_loop"
+        ]
         filtered_attr = {key: val for key, val in _all_attr.items() if key.startswith('_') is False}
         filtered_attr = {key: val for key, val in filtered_attr.items() if
                          key not in excludes and type(val).__name__ != 'function'}
@@ -1643,8 +1654,34 @@ class MonitorAgent(AgentMET4FOF):
         Used to specifically select only a few keys to be plotted
     """
 
-    def init_parameters(self, plot_filter=[], custom_plot_function=-1, *args, **kwargs):
-        self.memory = {}
+    def init_parameters(
+        self,
+        plot_filter: List[str] = None,
+        custom_plot_function: Callable[
+            [Union[List, np.ndarray, pd.DataFrame], str, Any, ...], Scatter
+        ] = None,
+        *args,
+        **kwargs
+    ):
+        """Initialize the monitor agent's parameters
+
+        Parameters
+        ----------
+        plots : dict
+            Dictionary of format `{agent1_name : agent1_plot, agent2_name : agent2_plot}`
+        plot_filter : list of str
+            List of keys to filter the 'data' upon receiving message to be saved into memory
+            Used to specifically select only a few keys to be plotted
+        custom_plot_function : callable
+            a custom plot function that can be provided to handle the data in the
+            monitor agents buffer (see :class:`AgentMET4FOF` for details). The function
+            gets provided with the content (value) of the buffer and with the string of the
+            sender agent's name as stored in the buffer's keys. Additionally any other
+            parameters can be provided as a dict in custom_plot_parameters.
+        custom_plot_parameters : dict
+            a custom dictionary of parameters that shall be provided to each call of the
+            custom_plot_function
+        """
         self.plots = {}
         self.plot_filter = plot_filter
         self.custom_plot_function = custom_plot_function

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -155,7 +155,7 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
         Method to reset the agent's states and parameters. User can override this method to reset the specific parameters.
         """
         self.log_info("RESET AGENT STATE")
-        self.memory = {}
+        self.buffer.clear()
 
     def init_parameters(self):
         """

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -267,7 +267,7 @@ class AgentMET4FOF(MesaAgent, osBrainAgent):
         """
         return self.buffer.buffer_filled(agent_name)
 
-    def buffer_clear(self, agent_name: str = None):
+    def buffer_clear(self, agent_name: Optional[str] = None):
         """
         Empties buffer which is a dict indexed by the `agent_name`.
 

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1663,9 +1663,7 @@ class MonitorAgent(AgentMET4FOF):
     def init_parameters(
         self,
         plot_filter: List[str] = None,
-        custom_plot_function: Callable[
-            [Union[List, np.ndarray, pd.DataFrame], str, Any, ...], Scatter
-        ] = None,
+        custom_plot_function: Callable[..., Scatter] = None,
         *args,
         **kwargs
     ):

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -1694,7 +1694,7 @@ class MonitorAgent(AgentMET4FOF):
         Handles incoming data from 'default' and 'plot' channels.
 
         Stores 'default' data into :attr:`buffer` and 'plot' data into
-        :attr:``self.plots``
+        :attr:`plots`
 
         Parameters
         ----------

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -417,20 +417,20 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             style_graphs = [{'opacity': 0, 'width': 10, 'height': 10} for i in range(app.num_monitors)]
 
             for monitor_id, monitor_agent in enumerate(agent_names):
-                memory_data = agentNetwork.get_agent(monitor_agent).get_attr('buffer').buffer
+                monitor_buffer = agentNetwork.get_agent(monitor_agent).get_attr('buffer').buffer
                 custom_plot_function = agentNetwork.get_agent(monitor_agent).get_attr('custom_plot_function')
                 data = []
-                for sender_agent in memory_data.keys():
+                for sender_agent, buffered_data in monitor_buffer.items():
                     # if custom plot function is not provided, resolve to default plotting
-                    if type(custom_plot_function).__name__ == "int":
-                        traces = create_monitor_graph(memory_data[sender_agent], sender_agent)
+                    if custom_plot_function is None:
+                        traces = create_monitor_graph(buffered_data, sender_agent)
                     # otherwise call custom plot function and load up custom plot parameters
                     else:
                         custom_plot_parameters = agentNetwork.get_agent(monitor_agent).get_attr(
                             'custom_plot_parameters')
                         # Handle iterable of traces.
                         traces = custom_plot_function(
-                            memory_data[sender_agent],
+                            buffered_data,
                             sender_agent,
                             **custom_plot_parameters
                         )
@@ -452,13 +452,13 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                 # Check if any metadata is present that can be used to generate axis
                 # labels or otherwise use default labels.
                 if (
-                    len(memory_data) > 0
-                    and isinstance(memory_data[sender_agent], dict)
-                    and "metadata" in memory_data[sender_agent].keys()
+                    len(monitor_buffer) > 0
+                    and isinstance(buffered_data, dict)
+                    and "metadata" in buffered_data.keys()
                 ):
                     # The metadata currently is always a list in the
                     # beginning containing at least one element.
-                    desc = memory_data[sender_agent]["metadata"][0]
+                    desc = buffered_data["metadata"][0]
 
                     # We now expect metadata to be of type
                     # time-series-metadata.scheme.MetaData. We try to access the

--- a/agentMET4FOF/dashboard/LayoutHelper.py
+++ b/agentMET4FOF/dashboard/LayoutHelper.py
@@ -1,10 +1,12 @@
+from typing import Dict, Union
+
 import dash_html_components as html
 import dash_table
-
 import networkx as nx
 import numpy as np
-import plotly.graph_objs as go
 import pandas as pd
+import plotly.graph_objs as go
+from plotly.graph_objs import Scatter
 
 
 #return icon and text for button
@@ -28,26 +30,49 @@ def create_edges_cytoscape(edges):
         new_elements += [{'data': {'source': edge[0], 'target': edge[1]}}]
     return new_elements
 
-def create_monitor_graph(data,sender_agent = 'Monitor Agent'):
+def create_monitor_graph(
+    data: Union[Dict, np.ndarray], sender_agent: str = "Monitor Agent"
+) -> Scatter:
     """
     Parameters
     ----------
-    data : dict or np.darray
-        The data saved in the MonitorAgent's memory, for each Inputs (Agents) it is connected to.
+    data : dict or np.ndarray
+        The data saved in the MonitorAgent's buffer, for each Inputs (Agents) it is
+        connected to.
     sender_agent : str
         Name of the sender agent
-    **kwargs
-        Custom parameters
+
+    Returns
+    -------
+    Scatter
+        Plotly scatter plot of the data
     """
     if isinstance(data, dict):
-        if 'time' not in data.keys():
-            trace = [go.Scatter(x=np.arange(len(data[key])), y=data[key],mode="lines", name=sender_agent+':'+key) for key in data.keys()]
+        if "time" not in data.keys():
+            trace = [
+                go.Scatter(
+                    x=np.arange(len(data[key])),
+                    y=data[key],
+                    mode="lines",
+                    name=f"{sender_agent}:{key}",
+                )
+                for key in data.keys()
+            ]
         else:
-            trace = [go.Scatter(x=data['time'], y=data[key],mode="lines", name=sender_agent+':'+key) for key in data.keys() if key !='time']
+            trace = [
+                go.Scatter(
+                    x=data["time"],
+                    y=data[key],
+                    mode="lines",
+                    name=f"{sender_agent}:{key}",
+                )
+                for key in data.keys()
+                if key != "time"
+            ]
     else:
         y = data
         x = np.arange(len(y))
-        trace = go.Scatter(x=x, y=y,mode="lines", name=sender_agent)
+        trace = go.Scatter(x=x, y=y, mode="lines", name=sender_agent)
     return trace
 
 def create_params_table(table_name="",data={}, columns=None, **kwargs):

--- a/tests/test_metadata_metrological_agent.py
+++ b/tests/test_metadata_metrological_agent.py
@@ -126,11 +126,11 @@ def test_simple_metrological_agent(agent_network):
             # Run actual check. This reduces test runtime in case of passed tests but
             # results in quite cryptic error messages in case it fails due to the
             # timeout causing the actual fail. So, if this line fails, regardless of
-            # the error message, it means, the addressed attribute'S content does not
+            # the error message, it means, the addressed attribute's content does not
             # match the expected expression.
             # Check if key 'metadata' is present in the received data
-            memory_dict = list(monitor_agent_1.get_attr('buffer').values())[0]
-            is_present = "metadata" in memory_dict.keys()
+            buffer_dict = list(monitor_agent_1.get_attr('buffer').values())[0]
+            is_present = "metadata" in buffer_dict.keys()
         except IndexError:
             pass
 


### PR DESCRIPTION
We spotted a left over from the times of `self.memory` in _agents.py_ and went to correct that. Then we stumbled across some minor issues in old docstrings and a loop over a dictionary via the key, where we could simply loop over keys and values. Hope this breaks nothing.