### PR TITLE
Introduce python-semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           command: |
             unset CIRCLE_PULL_REQUEST CIRCLE_PULL_REQUESTS CI_PULL_REQUEST \
               CI_PULL_REQUESTS
-            export CIRCLE_BRANCH=master
+            export CIRCLE_BRANCH=devel
             source venv/bin/activate
             git config --global user.name "semantic-release (via CircleCI)"
             git config --global user.email "bjoern.ludwig@ptb.de"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
       - run:
           name: Run semantic-release publish
           command: |
-            source ${PYENV}/bin/activate
+            source venv/bin/activate
             git config --global user.name "semantic-release (via CircleCI)"
             git config --global user.email "bjoern.ludwig@ptb.de"
             semantic-release publish
@@ -275,7 +275,7 @@ jobs:
             unset CIRCLE_PULL_REQUEST CIRCLE_PULL_REQUESTS CI_PULL_REQUEST \
               CI_PULL_REQUESTS
             export CIRCLE_BRANCH=master
-            source ${PYENV}/bin/activate
+            source venv/bin/activate
             git config --global user.name "semantic-release (via CircleCI)"
             git config --global user.email "bjoern.ludwig@ptb.de"
             echo "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,35 +19,35 @@ workflows:
   # Create workflow for testing and deploying agentMET4FOF.
   test_and_deploy:
     jobs:
-      - test_against_venv:
-          filters:
-            tags:
-              # Include tag filter to trigger as well on tag pushes.
-              only: /.*/
-      - test_against_conda:
-          filters:
-            tags:
-              # Include tag filter to trigger as well on tag pushes.
-              only: /.*/
-      - test_against_setup:
-          filters:
-            tags:
-              # Include tag filter to trigger as well on tag pushes.
-              only: /.*/
-      - deploy:
-          # Create 'deploy' job to upload agentMET4FOF to PyPI.org on certain tag
-          # pushes, which successfully run 'test' job and are tagged with version.
+      - test_against_venv
+      - test_against_conda
+      - test_against_setup
+      - preview_release:
+          # Test the 'release' job to avoid trouble when Pull Requests get merged and
+          # to preview publishing actions and the new changelog.
           requires:
-              - test_against_venv
-              - test_against_conda
-              - test_against_setup
+            - test_against_venv
+            - test_against_conda
+            - test_against_setup
+      - confirm_previewed_release_actions:
+          # This job allows for checking that the release we will create in the
+          # next step actually is the desired release, by observing the result of
+          # preview_release.
+          type: approval
+          requires:
+            - preview_release
           filters:
-              tags:
-                # Specify the tags which trigger the job as regular expression.
-                only: /[0-9]*+(\.[0-9]+)*+(\.(dev)[0-9]+|((a|b)|rc)[0-9]+)?/
-              branches:
-                # This assures the job only being triggered by tag pushes.
-                ignore: /.*/
+            branches:
+              # This assures the job only being triggered on branch master.
+              only: /develop/
+      - release:
+          # Job to potentially create a release based on python-semantic-release's
+          # decision and publish it on GitHub, Zenodo and PyPI.org. This requires manual
+          # approval in the previous step, which is only triggered on branch master,
+          # thus this job here is triggered only on master as well.
+          context: pypi.org publishing for agentMET4FOF
+          requires:
+            - confirm_previewed_release_actions
 
 commands:
   # Reusable command to prepare the environment for testing.
@@ -58,7 +58,7 @@ commands:
     - run:
         name: Create test result folder
         command: |
-          mkdir -p test-reports
+          mkdir -p test-results
 
   run_venv_tests:
     description: "Run and store test results."
@@ -102,6 +102,15 @@ commands:
 
     - store_test_results:
         path: test-reports
+
+  install_deps:
+    description: "Install dependencies."
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            source venv/bin/activate
+            pip install -r requirements.txt -r dev-requirements.txt
 
 jobs:
   # Define one 'test' job to run their test suites against the
@@ -232,65 +241,49 @@ jobs:
       # Run tests! We use pytest's test-runner.
       - run_venv_tests
 
-  deploy:
-    executor: publisher
+  release:
+    executor:
+      name: publisher
 
     steps:
-      # Checkout code.
       - checkout
+      - install_deps
 
-      # Download and cache dependencies.
-      - restore_cache:
-          keys:
-            # Specify the unique identifier for the cache.
-            - v1-dependencies-deploy-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
-            # Fallback to using the latest cache if no exact match is found.
-            - v1-dependencies-deploy-
-
-      # Install dependencies if necessary.
+      # Publish it, if there is anything to publish!
       - run:
-         name: Install dependencies
-         command: |
-           python3 -m venv agent_venv
-           source agent_venv/bin/activate
-           pip install --upgrade -r requirements.txt
-           pip install --upgrade setuptools wheel twine
-
-      - save_cache:
-          paths:
-            - ./agent_venv
-          key: v1-dependencies-deploy-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
-
-      # Verify Git tag to version to ensure, only wanted versions are uploaded.
-      - run:
-          name: Verify Git tag vs. version
+          name: Run semantic-release publish
           command: |
-            source agent_venv/bin/activate
-            python setup.py verify
+            source ${PYENV}/bin/activate
+            git config --global user.name "semantic-release (via CircleCI)"
+            git config --global user.email "bjoern.ludwig@ptb.de"
+            semantic-release publish
 
-      # Create a package.
+  preview_release:
+    executor:
+      name: publisher
+
+    steps:
+      - checkout
+      - install_deps
+
+      # Fake publish, just to make sure everything works after merging a PR and
+      # before actual release jos run.
       - run:
-          name: Create package
+          name: Preview python-semantic-release actions
           command: |
-            source agent_venv/bin/activate
-            python3 setup.py sdist bdist_wheel
+            unset CIRCLE_PULL_REQUEST CIRCLE_PULL_REQUESTS CI_PULL_REQUEST \
+              CI_PULL_REQUESTS
+            export CIRCLE_BRANCH=master
+            source ${PYENV}/bin/activate
+            git config --global user.name "semantic-release (via CircleCI)"
+            git config --global user.email "bjoern.ludwig@ptb.de"
+            echo "
+            The changelog of the next release will contain:
+            "
+            semantic-release --unreleased changelog
+            echo "
+            -----------------------------------------------------------
 
-      # Store test results as artifacts.
-      - store_artifacts:
-         path: dist
-         destination: dist
-
-      # We create a .pypirc to provide the username and password.
-      - run:
-          name: Create .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username: __token__" >> ~/.pypirc
-            echo -e "password: $PYPI_PASSWORD" >> ~/.pypirc
-
-      # Upload the created packages to test.pypi.org.
-      - run:
-          name: Upload to PyPI.org
-          command: |
-            source agent_venv/bin/activate
-            twine upload dist/*
+            python-semantic-release would perform the following actions:
+            "
+            semantic-release --noop publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           command: |
             unset CIRCLE_PULL_REQUEST CIRCLE_PULL_REQUESTS CI_PULL_REQUEST \
               CI_PULL_REQUESTS
-            export CIRCLE_BRANCH=devel
+            export CIRCLE_BRANCH=develop
             source venv/bin/activate
             git config --global user.name "semantic-release (via CircleCI)"
             git config --global user.email "bjoern.ludwig@ptb.de"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
         name: Run tests
         command: |
           source venv/bin/activate
-          tox | tee --append test-reports/agentMET4FOF.log
+          tox | tee --append test-results/agentMET4FOF.log
 
     # Upload coverage report if the according parameter is set to `true`.
     - when:
@@ -97,11 +97,11 @@ commands:
     steps:
     # Store test results.
     - store_artifacts:
-        path: test-reports
-        destination: test-reports
+        path: test-results
+        destination: test-results
 
     - store_test_results:
-        path: test-reports
+        path: test-results
 
   install_deps:
     description: "Install dependencies."
@@ -167,7 +167,7 @@ jobs:
           command: |
             source $HOME/conda/etc/profile.d/conda.sh
             conda activate agentMET4FOF
-            tox | tee --append test-reports/agentMET4FOF.log
+            tox | tee --append test-results/agentMET4FOF.log
 
       - store_test_artifacts_and_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,13 @@ commands:
     - store_test_results:
         path: test-results
 
-  install_deps:
+  install_all_deps:
     description: "Install dependencies."
     steps:
       - run:
           name: Install dependencies
           command: |
+            python3 -m venv venv
             source venv/bin/activate
             pip install -r requirements.txt -r dev-requirements.txt
 
@@ -247,7 +248,7 @@ jobs:
 
     steps:
       - checkout
-      - install_deps
+      - install_all_deps
 
       # Publish it, if there is anything to publish!
       - run:
@@ -264,7 +265,7 @@ jobs:
 
     steps:
       - checkout
-      - install_deps
+      - install_all_deps
 
       # Fake publish, just to make sure everything works after merging a PR and
       # before actual release jos run.

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -11,3 +11,4 @@ recommonmark
 sphinx_rtd_theme
 ipython
 tox
+python-semantic-release

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,19 +19,34 @@ babel==2.9.0
 backcall==0.2.0
     # via ipython
 bleach==3.3.0
-    # via nbconvert
+    # via
+    #   nbconvert
+    #   readme-renderer
 certifi==2020.12.5
     # via
     #   -c requirements.txt
     #   requests
+cffi==1.14.5
+    # via cryptography
 chardet==4.0.0
     # via
     #   -c requirements.txt
     #   requests
+click-log==0.3.2
+    # via python-semantic-release
+click==7.1.2
+    # via
+    #   -c requirements.txt
+    #   click-log
+    #   python-semantic-release
+colorama==0.4.4
+    # via twine
 commonmark==0.9.1
     # via recommonmark
 coverage==5.4
     # via pytest-cov
+cryptography==3.4.6
+    # via secretstorage
 decorator==4.4.2
     # via
     #   -c requirements.txt
@@ -43,14 +58,21 @@ distlib==0.3.1
 docutils==0.16
     # via
     #   nbsphinx
+    #   readme-renderer
     #   recommonmark
     #   sphinx
+dotty-dict==1.3.0
+    # via python-semantic-release
 entrypoints==0.3
     # via nbconvert
 filelock==3.0.12
     # via
     #   tox
     #   virtualenv
+gitdb==4.0.5
+    # via gitpython
+gitpython==3.1.13
+    # via python-semantic-release
 idna==2.10
     # via
     #   -c requirements.txt
@@ -59,6 +81,8 @@ imagesize==1.2.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
+invoke==1.5.0
+    # via python-semantic-release
 ipython-genutils==0.2.0
     # via
     #   nbformat
@@ -67,6 +91,10 @@ ipython==7.20.0
     # via -r dev-requirements.in
 jedi==0.18.0
     # via ipython
+jeepney==0.6.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via
     #   -c requirements.txt
@@ -84,13 +112,15 @@ jupyter-core==4.7.1
     #   nbformat
 jupyterlab-pygments==0.1.2
     # via nbconvert
+keyring==22.0.1
+    # via twine
 markupsafe==1.1.1
     # via
     #   -c requirements.txt
     #   jinja2
 mistune==0.8.4
     # via nbconvert
-nbclient==0.5.1
+nbclient==0.5.2
     # via nbconvert
 nbconvert==6.0.7
     # via nbsphinx
@@ -117,11 +147,13 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkginfo==1.7.0
+    # via twine
 pluggy==0.13.1
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.14
+prompt-toolkit==3.0.16
     # via ipython
 psutil==5.8.0
     # via -r dev-requirements.in
@@ -131,11 +163,14 @@ py==1.10.0
     # via
     #   pytest
     #   tox
-pygments==2.7.4
+pycparser==2.20
+    # via cffi
+pygments==2.8.0
     # via
     #   ipython
     #   jupyterlab-pygments
     #   nbconvert
+    #   readme-renderer
     #   sphinx
 pyparsing==2.4.7
     # via
@@ -156,34 +191,58 @@ python-dateutil==2.8.1
     # via
     #   -c requirements.txt
     #   jupyter-client
+python-gitlab==1.15.0
+    # via python-semantic-release
+python-semantic-release==7.15.0
+    # via -r dev-requirements.in
 pytz==2021.1
     # via
     #   -c requirements.txt
     #   babel
-pyzmq==22.0.2
+pyzmq==22.0.3
     # via
     #   -c requirements.txt
     #   jupyter-client
+readme-renderer==29.0
+    # via twine
 recommonmark==0.7.1
     # via -r dev-requirements.in
+requests-toolbelt==0.9.1
+    # via twine
 requests==2.25.1
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
+    #   python-gitlab
+    #   python-semantic-release
+    #   requests-toolbelt
     #   sphinx
+    #   twine
+rfc3986==1.4.0
+    # via twine
+secretstorage==3.3.1
+    # via keyring
+semver==2.13.0
+    # via python-semantic-release
+setuptools-scm==5.0.1
+    # via dotty-dict
 six==1.15.0
     # via
     #   -c requirements.txt
     #   bleach
     #   jsonschema
     #   python-dateutil
+    #   python-gitlab
+    #   readme-renderer
     #   tox
     #   virtualenv
+smmap==3.0.5
+    # via gitdb
 snowballstemmer==2.1.0
     # via sphinx
 sphinx-rtd-theme==0.5.1
     # via -r dev-requirements.in
-sphinx==3.4.3
+sphinx==3.5.1
     # via
     #   -r dev-requirements.in
     #   nbsphinx
@@ -207,12 +266,18 @@ toml==0.10.2
     # via
     #   pytest
     #   tox
+tomlkit==0.7.0
+    # via python-semantic-release
 tornado==6.1
     # via
     #   -c requirements.txt
     #   jupyter-client
-tox==3.21.4
+tox==3.22.0
     # via -r dev-requirements.in
+tqdm==4.57.0
+    # via
+    #   -c requirements.txt
+    #   twine
 traitlets==5.0.5
     # via
     #   ipython
@@ -222,6 +287,8 @@ traitlets==5.0.5
     #   nbconvert
     #   nbformat
     #   nbsphinx
+twine==3.3.0
+    # via python-semantic-release
 urllib3==1.26.3
     # via
     #   -c requirements.txt
@@ -232,6 +299,8 @@ wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
+wheel==0.36.2
+    # via python-semantic-release
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,6 +7,17 @@ established workflows. This guide should work on all platforms and provide every
 needed to start developing for agentMET4FOF. Please open an issue or ideally contribute
 to this guide as a start, if problems or questions arise.
 
+## Guiding principles
+
+The agentMET4FOF development process is based on the following guiding principles: 
+
+- actively maintain, ensuring security vulnerabilities or other issues
+  are resolved in a timely manner 
+- employ state-of-the-art development practices and tools, specifically
+  - follow [semantic versioning](https://semver.org/)
+  - use [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
+  - consider the PEP8 style guide, wherever feasible
+
 ### Get the code on GitHub and locally
 
 For collaboration, we recommend forking the repository as described [here](https://help.github.com/en/articles/fork-a-repo).
@@ -37,6 +48,7 @@ you have everything at your hands:
 - [_pytest_](https://pypi.org/project/pytest/) as testing framework backed by
   [_hypothesis_](https://pypi.org/project/hypothesis/) and
   [_coverage_](https://pypi.org/project/coverage/).
+- [_python-semantic-release_](https://github.com/relekang/python-semantic-release) in
 - [our pipeline on _CircleCI_](https://app.circleci.com/pipelines/github/Met4FoF/agentMET4FOF)
 . All requirements for contributions are derived from this. 
 
@@ -52,7 +64,40 @@ such that it is automatically applied.
 
 ### Commit messages
 
-agentMET4FOF commit messages follow some conventions to be easily readable.
+agentMET4FOF commit messages follow some conventions to be easily human and
+machine-readable.
+
+#### Commit message structure
+
+[Conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+are required for the following:
+
+- Releasing automatically according to [semantic versioning](https://semver.org/)
+- [Generating  a changelog automatically](https://github.com/PTB-PSt1/PyDynamic/releases/tag/v1.4.0)
+
+Parts of the commit messages and links appear in the changelogs of subsequent
+releases as a result. We use the following types:
+
+- _feat_: for commits that introduce new features (this correlates with MINOR in
+  semantic versioning)
+- _docs_: for commits that contribute significantly to documentation
+- _fix_: commits in which bugs are fixed (this correlates with PATCH in semantic
+  versioning)
+- _test_: Commits that apply significant changes to tests
+- _chore_: Commits that affect other non-PyDynamic components (e.g. ReadTheDocs, Git
+, ... )
+- _revert_: commits, which undo previous commits using `git revert`
+- _wip_: Commits which are not recognizable as one of the above-mentioned types until
+  later, usually during a PR merge.  The merge commit is then marked as the
+  corresponding type.
+
+Of the types mentioned above, the following appear in separate sections of the
+changelog:
+
+- _Feature_: _feat_
+- _Documentation_: _docs_
+- _Fix_: _fix_
+- _Test_: _test_
 
 #### Commit message styling
 
@@ -64,7 +109,14 @@ complete the following sentence:
 More comprehensive messages should contain an empty line after that and everything else
 needed starting from the third line. Each line should not exceed 100 characters.
 
-#### Examples
+#### BREAKING CHANGEs
+
+Since agentMET4FOF is not yet considered stable, we do not mark BREAKING CHANGES. As a
+consequence, at any time commits may changes parts of agentMET4FOF's public interface so
+that previously written code may no longer be executable. If this occurs we try though,
+to mention migration strategies in the corresponding release descriptions.
+
+#### Commit message examples
 
 For examples please checkout the
 [Git Log](https://github.com/Met4FoF/agentMET4FOF/commits/master).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,7 +158,7 @@ author = (
 # built documents.
 #
 # The short X.Y version.
-# version = '0.0.1'
+version = '0.6.0'
 # The full version, including alpha/beta/rc tags.
 # release = '0.0.1'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ dill==0.3.3
     #   multiprocess
     #   osbrain
     #   pathos
-flask-compress==1.8.0
+flask-compress==1.9.0
     # via dash
 flask==1.1.2
     # via
@@ -129,13 +129,13 @@ python-slugify==4.0.1
     # via cookiecutter
 pytz==2021.1
     # via pandas
-pyzmq==22.0.2
+pyzmq==22.0.3
     # via osbrain
 requests==2.25.1
     # via cookiecutter
 retrying==1.3.3
     # via plotly
-scipy==1.6.0
+scipy==1.6.1
     # via agentMET4FOF (setup.py)
 serpent==1.30.2
     # via pyro4
@@ -155,7 +155,7 @@ time-series-metadata==0.1.0
     # via agentMET4FOF (setup.py)
 tornado==6.1
     # via mesa
-tqdm==4.56.0
+tqdm==4.57.0
     # via mesa
 uncertainties==3.1.5
     # via time-series-buffer

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[semantic_release]
+# The file(s) and variable name of where the version number is stored.
+version_variable = agentMET4FOF/__init__.py:__version__,docs/conf.py:version
+# The way we get and set the new version. Can be commit or tag.
+# If set to tag, will get the current version from the latest tag matching vX.Y.Z.
+# This won’t change the source defined in version_variable.
+# If set to commit, will get the current version from the source defined in
+# version_variable, edit the file and commit it.
+version_source = commit
+# Import path of a Python function that can parse commit messages and return
+# information about the commit.
+commit_parser = semantic_release.history.angular_parser
+# If set to false the pypi uploading will be disabled.
+upload_to_pypi=true
+# If set to false, do not upload distributions to GitHub releases.
+upload_to_release=true
+# The branch to run releases from.
+branch=develop
+# The name of your hvcs. Currently only GitHub and GitLab are supported.
+hvcs=github
+# Whether or not to commit changes when bumping version.
+commit_version_number=true
+# The name of the file where the changelog is kept, relative to the root of the repo.
+changelog_file=docs/CHANGELOG.md
+# Comma-separated list of sections to display in the changelog. They will be
+# displayed in the order they are given. The available options depend on the commit
+# parser used.
+changelog_sections = feature,fix,breaking,documentation,performance
+# A comma-separated list of the import paths of components to include in the changelog.
+changelog_components = semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url


### PR DESCRIPTION
This is to half-automate the release process and introduce the creation and maintain a `docs/CHANGELOG.md` to prepare for automatic release creation.

We resolve #52 with this.