### PR TITLE
Replace pathos by multiprocess

### DIFF
--- a/agentMET4FOF/dashboard/Dashboard.py
+++ b/agentMET4FOF/dashboard/Dashboard.py
@@ -7,7 +7,7 @@ from wsgiref.simple_server import make_server
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import pathos
+from multiprocess.context import Process
 
 from .Dashboard_Control import _Dashboard_Control
 
@@ -157,8 +157,7 @@ class AgentDashboard:
             return True
 
 
-
-class AgentDashboardProcess(AgentDashboard, pathos.helpers.mp.Process):
+class AgentDashboardProcess(AgentDashboard, Process):
     """Represents an agent dashboard for the osBrain backend"""
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,7 @@ colorama==0.4.4
     # via twine
 commonmark==0.9.1
     # via recommonmark
-coverage==5.4
+coverage==5.5
     # via pytest-cov
 cryptography==3.4.6
     # via secretstorage
@@ -51,7 +51,7 @@ decorator==4.4.2
     # via
     #   -c requirements.txt
     #   ipython
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via nbconvert
 distlib==0.3.1
     # via virtualenv
@@ -71,7 +71,7 @@ filelock==3.0.12
     #   virtualenv
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.13
+gitpython==3.1.14
     # via python-semantic-release
 idna==2.10
     # via
@@ -79,6 +79,8 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==3.7.2
+    # via keyring
 iniconfig==1.1.1
     # via pytest
 invoke==1.5.0
@@ -87,7 +89,7 @@ ipython-genutils==0.2.0
     # via
     #   nbformat
     #   traitlets
-ipython==7.20.0
+ipython==7.21.0
     # via -r dev-requirements.in
 jedi==0.18.0
     # via ipython
@@ -112,7 +114,7 @@ jupyter-core==4.7.1
     #   nbformat
 jupyterlab-pygments==0.1.2
     # via nbconvert
-keyring==22.0.1
+keyring==23.0.0
     # via twine
 markupsafe==1.1.1
     # via
@@ -120,7 +122,7 @@ markupsafe==1.1.1
     #   jinja2
 mistune==0.8.4
     # via nbconvert
-nbclient==0.5.2
+nbclient==0.5.3
     # via nbconvert
 nbconvert==6.0.7
     # via nbsphinx
@@ -129,7 +131,7 @@ nbformat==5.1.2
     #   nbclient
     #   nbconvert
     #   nbsphinx
-nbsphinx==0.8.1
+nbsphinx==0.8.2
     # via -r dev-requirements.in
 nest-asyncio==1.5.1
     # via nbclient
@@ -153,7 +155,7 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.17
     # via ipython
 psutil==5.8.0
     # via -r dev-requirements.in
@@ -165,7 +167,7 @@ py==1.10.0
     #   tox
 pycparser==2.20
     # via cffi
-pygments==2.8.0
+pygments==2.8.1
     # via
     #   ipython
     #   jupyterlab-pygments
@@ -224,7 +226,7 @@ secretstorage==3.3.1
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==5.0.1
+setuptools-scm==5.0.2
     # via dotty-dict
 six==1.15.0
     # via
@@ -242,7 +244,7 @@ snowballstemmer==2.1.0
     # via sphinx
 sphinx-rtd-theme==0.5.1
     # via -r dev-requirements.in
-sphinx==3.5.1
+sphinx==3.5.2
     # via
     #   -r dev-requirements.in
     #   nbsphinx
@@ -272,9 +274,9 @@ tornado==6.1
     # via
     #   -c requirements.txt
     #   jupyter-client
-tox==3.22.0
+tox==3.23.0
     # via -r dev-requirements.in
-tqdm==4.57.0
+tqdm==4.59.0
     # via
     #   -c requirements.txt
     #   twine
@@ -301,6 +303,8 @@ webencodings==0.5.1
     # via bleach
 wheel==0.36.2
     # via python-semantic-release
+zipp==3.4.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-arrow==0.17.0
+arrow==1.0.3
     # via jinja2-time
 binaryornot==0.4.4
     # via cookiecutter
@@ -47,7 +47,6 @@ dill==0.3.3
     # via
     #   multiprocess
     #   osbrain
-    #   pathos
 flask-compress==1.9.0
     # via dash
 flask==1.1.2
@@ -85,7 +84,7 @@ mesa==0.8.8.1
 mpld3==0.5.2
     # via agentMET4FOF (setup.py)
 multiprocess==0.70.11.1
-    # via pathos
+    # via agentMET4FOF (setup.py)
 networkx==2.5
     # via
     #   agentMET4FOF (setup.py)
@@ -100,22 +99,16 @@ numpy==1.20.1
     #   time-series-buffer
 osbrain==0.6.5
     # via agentMET4FOF (setup.py)
-pandas==1.2.2
+pandas==1.2.3
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
-pathos==0.2.7
-    # via agentMET4FOF (setup.py)
 plotly==4.14.3
     # via
     #   agentMET4FOF (setup.py)
     #   dash
-pox==0.2.9
-    # via pathos
 poyo==0.5.0
     # via cookiecutter
-ppft==1.6.6.3
-    # via pathos
 pyparsing==2.4.7
     # via matplotlib
 pyro4==4.80
@@ -144,7 +137,6 @@ six==1.15.0
     #   cookiecutter
     #   cycler
     #   plotly
-    #   ppft
     #   python-dateutil
     #   retrying
 text-unidecode==1.3
@@ -155,7 +147,7 @@ time-series-metadata==0.1.0
     # via agentMET4FOF (setup.py)
 tornado==6.1
     # via mesa
-tqdm==4.57.0
+tqdm==4.59.0
     # via mesa
 uncertainties==3.1.5
     # via time-series-buffer

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "time-series-metadata",
         "mpld3",
         "mesa",
-        "pathos",
+        "multiprocess",
     ],
     extras_require={"tutorials": ["notebook", "PyDynamic"]},
     python_requires=">=3.8",


### PR DESCRIPTION
We have introduced a dependency `pathos` but only  use their class Process, which in turn looks, as if it is simply the `multiprocess.context.Process` class, they themselves import from another third-party library `multiprocess`. It should suffice to directly use the `multiprocess.context.Process`.

Notice my [comment on my thoughts in the corresponding issue](https://github.com/Met4FoF/agentMET4FOF/issues/189#issuecomment-800204272) and especially the difference between in-built _multiprocess**ing**_ and the fork _multiprocess_ from the _pathos_ guys. 

@bangxiangyong Please check if everything for which you introduced the `pathos` import in _agentMET4FOF.dashboard.Dashboard_ still works.

This is meant to resolve #189 .