### PR TITLE
Include CHANGELOG into docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ results/
 docs/_build
 docs/README.md
 docs/agentMET4FOF_tutorials
+docs/CHANGELOG.md
 
 # Build clutter #
 #################

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,10 @@
 ## v0.6.1 (2021-03-12)
 ### Fix
 * **metrological_streams:** Fixed computational error for batches of size more than one ([`686bad5`](https://github.com/Met4FoF/agentMET4FOF/commit/686bad58ee02b216ffb3c663c9492d7dd7aaf6df))
+* **agents:** Fixed `buffer.clear` method, which did not work anymore after moving from `memory` to `buffer`
 
 ### Documentation
 * **README:** Include the Zenodo DOI banner and add the Citation section ([`4a57dd8`](https://github.com/Met4FoF/agentMET4FOF/commit/4a57dd8402590b9439ecf3bc47fbf950c6d44c7d))
+* **docstrings:** Seriously improve docstrings and type hinting in `agents.py` and `dashboard/LayoutHelper.py`
 
-**[See all commits in this version](https://github.com/Met4FoF/agentMET4FOF/compare/v0.6.0...v0.6.1)**
+**[See all commits in this version](https://github.com/Met4FoF/agentMET4FOF/compare/0.6.0...v0.6.1)**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ html_theme_options = {
 # This should make Python built-in, Pandas, SciPy, PyDynamic and time-series-metadata
 # documentation available inside our docs.
 intersphinx_mapping = {
-    "Python": ("http://docs.python.org/", None),
+    "Python": ("https://docs.python.org/3", None),
     "pd": ("http://pandas.pydata.org/pandas-docs/dev", None),
     "SciPy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "PyDynamic": (
@@ -65,7 +65,7 @@ intersphinx_mapping = {
         None,
     ),
     "np": (
-        "http://docs.scipy.org/doc/numpy/",
+        "https://numpy.org/doc/stable/",
         None,
     ),
 }
@@ -91,6 +91,11 @@ nbsphinx_allow_errors = True
 shutil.copyfile(
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "README.md")),
     os.path.join(os.path.dirname(__file__), "README.md"),
+)
+# Copy over CHANGELOG from root folder.
+shutil.copyfile(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "CHANGELOG")),
+    os.path.join(os.path.dirname(__file__), "CHANGELOG.md"),
 )
 
 # Copy over all other specified folders from repository tree.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ agentMET4FOF - Metrological Agent-based system
    INSTALL
    UMLs
    CONTRIBUTING
+   CHANGELOG
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
That is obviously pretty minor, but now that we have the CHANGELOG I thought, we might as well show it. :smile: 

Check out the [new docs](https://agentmet4fof.readthedocs.io/en/add_changeog_to_docs/)!