### PR TITLE
Default metrological generator agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,9 @@ workflows:
           # decision and publish it on GitHub, Zenodo and PyPI.org. This requires manual
           # approval in the previous step, which is only triggered on branch master,
           # thus this job here is triggered only on master as well.
-          context: pypi.org publishing for agentMET4FOF
+          context:
+            - pypi.org publishing for agentMET4FOF
+            - GitHub pushes to BjoernLudwigPTB's public_repos
           requires:
             - confirm_previewed_release_actions
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ corresponding data analysis. An excellent way to represent such networks is a
 multi-agent system (MAS), where independent software modules (agents) encapsulate
 properties and functionalities. agentMET4FOF is an interactive and flexible open-source
 implementation of such a MAS. The software engineering process is driven by several
-industry-oriented use cases with the aim of impacting on IIoT applications. This leads
+industry-oriented use cases with the aim of enabling IIoT applications. This leads
 to a framework that is specialized in representing heterogeneous sensor networks.
 </p>
 <p align="justify">
-A special emphasize is put on supporting metrological treatment of sensor streaming
+A special emphasis is put on supporting metrological treatment of sensor streaming
 data. This includes the consideration of measurement uncertainties during data analysis
 and processing as well as propagating metadata alongside the data itself.
 </p>

--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -210,7 +210,6 @@ class MetrologicalGeneratorAgent(MetrologicalAgent):
     sample by sample to connected agents via its output channel.
     """
 
-    # The datatype of the stream will be MetrologicalSineGenerator.
     _stream: MetrologicalDataStreamMET4FOF
 
     def init_parameters(

--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -203,7 +203,7 @@ class MetrologicalMonitorAgent(MetrologicalAgent):
         return trace
 
 class MetrologicalGeneratorAgent(MetrologicalAgent):
-    """An agent streaming a sine signal
+    """An agent streaming a specified signal
 
     Takes samples from an instance of :py:class:`MetrologicalSineGenerator` with sampling frequency `sfreq` and
     signal frequency `sine_freq` and pushes them sample by sample to connected agents via its output channel.

--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -205,8 +205,9 @@ class MetrologicalMonitorAgent(MetrologicalAgent):
 class MetrologicalGeneratorAgent(MetrologicalAgent):
     """An agent streaming a specified signal
 
-    Takes samples from an instance of :py:class:`MetrologicalSineGenerator` with sampling frequency `sfreq` and
-    signal frequency `sine_freq` and pushes them sample by sample to connected agents via its output channel.
+    Takes samples from an instance of :py:class:`MetrologicalDataStreamMET4FOF
+    <agentMET4FOF.metrological_streams.MetrologicalDataStreamMET4FOF>` and pushes them
+    sample by sample to connected agents via its output channel.
     """
 
     # The datatype of the stream will be MetrologicalSineGenerator.

--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -221,8 +221,10 @@ class MetrologicalGeneratorAgent(MetrologicalAgent):
 
         Parameters
         ----------
-        signal : MetrologicalDataStreamMET4FOF
-            the underlying signal for the generator
+        signal : MetrologicalDataStreamMET4FOF, optional
+            the underlying signal for the generator, defaults to
+            :py:class:`MetrologicalSineGenerator 
+            <agentMET4FOF.metrological_streams.MetrologicalSineGenerator>`
         """
         self._stream = signal
         super().init_parameters()

--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -202,7 +202,7 @@ class MetrologicalMonitorAgent(MetrologicalAgent):
             trace = go.Scatter()
         return trace
 
-class MetrologicalSineGeneratorAgent(MetrologicalAgent):
+class MetrologicalGeneratorAgent(MetrologicalAgent):
     """An agent streaming a sine signal
 
     Takes samples from an instance of :py:class:`MetrologicalSineGenerator` with sampling frequency `sfreq` and
@@ -221,14 +221,8 @@ class MetrologicalSineGeneratorAgent(MetrologicalAgent):
 
         Parameters
         ----------
-        sine_freq : float
-            the frequency of the
-        sfreq : int
-            the sampling frequency of the generated signal
-        value_unc : iterable of floats or float, optional
-            standard uncertainty(ies) of the quantity values. Defaults to 0.1.
-        time_unc : iterable of floats or float, optional
-            standard uncertainty of the time stamps. Defaults to 0.
+        signal : MetrologicalDataStreamMET4FOF
+            the underlying signal for the generator
         """
         self._stream = signal
         super().init_parameters()

--- a/agentMET4FOF/metrological_streams.py
+++ b/agentMET4FOF/metrological_streams.py
@@ -232,7 +232,7 @@ class MetrologicalSineGenerator(MetrologicalDataStreamMET4FOF):
         the corresponding attribute of the created :class:`Metadata` object. Defaults to
         'Simple sine wave generator'.
     value_unc : iterable of floats or float, optional
-        standard uncertainty(ies) of the quantity values. Defaults to 0.5.
+        standard uncertainty(ies) of the quantity values. Defaults to 0.1.
     time_unc : iterable of floats or float, optional
         standard uncertainty of the time stamps. Defaults to 0.
     """

--- a/agentMET4FOF/metrological_streams.py
+++ b/agentMET4FOF/metrological_streams.py
@@ -306,7 +306,7 @@ class MetrologicalMultiWaveGenerator(MetrologicalDataStreamMET4FOF):
                  ampl_arr: np.array = np.array([1]),
                  phase_ini_arr: np.array = np.array([0]),
                  intercept: float = 0,
-                 device_id: str = "DataGenerator",
+                 device_id: str = "MultiWaveDataGenerator",
                  time_name: str = "time",
                  time_unit: str = "s",
                  quantity_names: Union[str, Tuple[str, ...]] = ("Length", "Mass"),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,7 +45,7 @@ commonmark==0.9.1
     # via recommonmark
 coverage==5.5
     # via pytest-cov
-cryptography==3.4.6
+cryptography==3.4.7
     # via secretstorage
 decorator==4.4.2
     # via
@@ -61,6 +61,7 @@ docutils==0.16
     #   readme-renderer
     #   recommonmark
     #   sphinx
+    #   sphinx-rtd-theme
 dotty-dict==1.3.0
     # via python-semantic-release
 entrypoints==0.3
@@ -69,7 +70,7 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-gitdb==4.0.5
+gitdb==4.0.7
     # via gitpython
 gitpython==3.1.14
     # via python-semantic-release
@@ -79,8 +80,10 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==3.7.2
-    # via keyring
+importlib-metadata==3.10.1
+    # via
+    #   keyring
+    #   twine
 iniconfig==1.1.1
     # via pytest
 invoke==1.5.0
@@ -89,7 +92,7 @@ ipython-genutils==0.2.0
     # via
     #   nbformat
     #   traitlets
-ipython==7.21.0
+ipython==7.22.0
     # via -r dev-requirements.in
 jedi==0.18.0
     # via ipython
@@ -105,7 +108,7 @@ jinja2==2.11.3
     #   sphinx
 jsonschema==3.2.0
     # via nbformat
-jupyter-client==6.1.11
+jupyter-client==6.1.12
     # via nbclient
 jupyter-core==4.7.1
     # via
@@ -114,7 +117,7 @@ jupyter-core==4.7.1
     #   nbformat
 jupyterlab-pygments==0.1.2
     # via nbconvert
-keyring==23.0.0
+keyring==23.0.1
     # via twine
 markupsafe==1.1.1
     # via
@@ -126,12 +129,12 @@ nbclient==0.5.3
     # via nbconvert
 nbconvert==6.0.7
     # via nbsphinx
-nbformat==5.1.2
+nbformat==5.1.3
     # via
     #   nbclient
     #   nbconvert
     #   nbsphinx
-nbsphinx==0.8.2
+nbsphinx==0.8.3
     # via -r dev-requirements.in
 nest-asyncio==1.5.1
     # via nbclient
@@ -143,7 +146,7 @@ packaging==20.9
     #   tox
 pandocfilters==1.4.3
     # via nbconvert
-parso==0.8.1
+parso==0.8.2
     # via jedi
 pexpect==4.8.0
     # via ipython
@@ -155,7 +158,7 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.17
+prompt-toolkit==3.0.18
     # via ipython
 psutil==5.8.0
     # via -r dev-requirements.in
@@ -184,7 +187,7 @@ pytest-cov==2.11.1
     # via -r dev-requirements.in
 pytest-timeout==1.4.2
     # via -r dev-requirements.in
-pytest==6.2.2
+pytest==6.2.3
     # via
     #   -r dev-requirements.in
     #   pytest-cov
@@ -193,9 +196,9 @@ python-dateutil==2.8.1
     # via
     #   -c requirements.txt
     #   jupyter-client
-python-gitlab==1.15.0
+python-gitlab==2.6.0
     # via python-semantic-release
-python-semantic-release==7.15.0
+python-semantic-release==7.15.3
     # via -r dev-requirements.in
 pytz==2021.1
     # via
@@ -210,7 +213,9 @@ readme-renderer==29.0
 recommonmark==0.7.1
     # via -r dev-requirements.in
 requests-toolbelt==0.9.1
-    # via twine
+    # via
+    #   python-gitlab
+    #   twine
 requests==2.25.1
     # via
     #   -c requirements.txt
@@ -226,7 +231,7 @@ secretstorage==3.3.1
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==5.0.2
+setuptools-scm==6.0.1
     # via dotty-dict
 six==1.15.0
     # via
@@ -234,17 +239,16 @@ six==1.15.0
     #   bleach
     #   jsonschema
     #   python-dateutil
-    #   python-gitlab
     #   readme-renderer
     #   tox
     #   virtualenv
-smmap==3.0.5
+smmap==4.0.0
     # via gitdb
 snowballstemmer==2.1.0
     # via sphinx
-sphinx-rtd-theme==0.5.1
+sphinx-rtd-theme==0.5.2
     # via -r dev-requirements.in
-sphinx==3.5.2
+sphinx==3.5.4
     # via
     #   -r dev-requirements.in
     #   nbsphinx
@@ -276,7 +280,7 @@ tornado==6.1
     #   jupyter-client
 tox==3.23.0
     # via -r dev-requirements.in
-tqdm==4.59.0
+tqdm==4.60.0
     # via
     #   -c requirements.txt
     #   twine
@@ -289,13 +293,13 @@ traitlets==5.0.5
     #   nbconvert
     #   nbformat
     #   nbsphinx
-twine==3.3.0
+twine==3.4.1
     # via python-semantic-release
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -c requirements.txt
     #   requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
     - defaults
 dependencies:
     - python = 3.8
+    - pip
     # pip dependencies have to be provided in `requirements.txt` syntax
     - pip:
         - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,19 +27,19 @@ cookiecutter==1.7.2
     # via mesa
 cycler==0.10.0
     # via matplotlib
-dash-core-components==1.15.0
+dash-core-components==1.16.0
     # via dash
 dash-cytoscape==0.2.0
     # via agentMET4FOF (setup.py)
-dash-html-components==1.1.2
+dash-html-components==1.1.3
     # via dash
-dash-table==4.11.2
+dash-table==4.11.3
     # via dash
-dash==1.19.0
+dash==1.20.0
     # via
     #   agentMET4FOF (setup.py)
     #   dash-cytoscape
-dash_renderer==1.9.0
+dash_renderer==1.9.1
     # via dash
 decorator==4.4.2
     # via networkx
@@ -85,11 +85,11 @@ mpld3==0.5.2
     # via agentMET4FOF (setup.py)
 multiprocess==0.70.11.1
     # via agentMET4FOF (setup.py)
-networkx==2.5
+networkx==2.5.1
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
-numpy==1.20.1
+numpy==1.20.2
     # via
     #   agentMET4FOF (setup.py)
     #   matplotlib
@@ -99,7 +99,7 @@ numpy==1.20.1
     #   time-series-buffer
 osbrain==0.6.5
     # via agentMET4FOF (setup.py)
-pandas==1.2.3
+pandas==1.2.4
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
@@ -128,7 +128,7 @@ requests==2.25.1
     # via cookiecutter
 retrying==1.3.3
     # via plotly
-scipy==1.6.1
+scipy==1.6.2
     # via agentMET4FOF (setup.py)
 serpent==1.30.2
     # via pyro4
@@ -147,11 +147,11 @@ time-series-metadata==0.1.0
     # via agentMET4FOF (setup.py)
 tornado==6.1
     # via mesa
-tqdm==4.59.0
+tqdm==4.60.0
     # via mesa
 uncertainties==3.1.5
     # via time-series-buffer
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
 werkzeug==1.0.1
     # via flask


### PR DESCRIPTION
A default generator agent has been added to metrological_agents.py. When no signal is specified, the MetrologicalSineGenerator is chosen as the input signal.