### PR TITLE
Reformat two of our docstrings to properly display those example values in the docs

### DIFF
--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -14,6 +14,14 @@ class MetrologicalAgent(AgentMET4FOF):
     #         "metadata": MetaData(**kwargs).metadata,
     #     }
     _input_data: Dict[str, Dict[str, Union[TimeSeriesBuffer, Dict]]]
+    """Input dictionary of all incoming data including metadata::
+
+        dict like {
+            <from>: {
+                "buffer": TimeSeriesBuffer(maxlen=buffer_size),
+                "metadata": MetaData(**kwargs).metadata,
+            }
+    """
     _input_data_maxlen: int
 
     # dict like {
@@ -22,6 +30,14 @@ class MetrologicalAgent(AgentMET4FOF):
     #         "metadata" : MetaData(**kwargs)
     #     }
     _output_data: Dict[str, Dict[str, Union[TimeSeriesBuffer, MetaData]]]
+    """Output dictionary of all outgoing data including metadata::
+
+        dict like {
+            <from>: {
+                "buffer": TimeSeriesBuffer(maxlen=buffer_size),
+                "metadata": MetaData(**kwargs).metadata,
+            }
+    """
     _output_data_maxlen: int
 
     def init_parameters(self, input_data_maxlen=25, output_data_maxlen=25):


### PR DESCRIPTION
Please compare the [old version](https://agentmet4fof.readthedocs.io/en/default_metrological_generator_agents/agentMET4FOF_metrological_agents.html) against the [new version](https://agentmet4fof.readthedocs.io/en/improve_docstrings_of_input_data_and_output_data/agentMET4FOF_metrological_agents.html).