### PR TITLE
Refactor metrological agents and streams to make imports relative

### DIFF
--- a/agentMET4FOF/metrological_agents.py
+++ b/agentMET4FOF/metrological_agents.py
@@ -6,11 +6,12 @@ import plotly.graph_objs as go
 from time_series_buffer import TimeSeriesBuffer
 from time_series_metadata.scheme import MetaData
 
-from agentMET4FOF.agents import AgentBuffer, AgentMET4FOF
+from .agents import AgentBuffer, AgentMET4FOF
 from .metrological_streams import (
     MetrologicalDataStreamMET4FOF,
     MetrologicalSineGenerator,
 )
+
 
 class MetrologicalAgent(AgentMET4FOF):
     # dict like {

--- a/agentMET4FOF/metrological_streams.py
+++ b/agentMET4FOF/metrological_streams.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
-from agentMET4FOF.streams import DataStreamMET4FOF
+from .streams import DataStreamMET4FOF
 
 
 class MetrologicalDataStreamMET4FOF(DataStreamMET4FOF):


### PR DESCRIPTION
When agentMET4FOF is used as a submodule in other packages, it is necessary to have relative imports in the core modules, as we noticed earlier (#79). This PR realizes this principle for the metrolgical modules.