### PR TITLE
Change delivery ip to 0.0.0.0, i.e. all interfaces instead of 127.0.0.1 to enable docker deployment

### DIFF
--- a/agentMET4FOF/dashboard/Dashboard.py
+++ b/agentMET4FOF/dashboard/Dashboard.py
@@ -77,16 +77,32 @@ class AgentDashboard:
     def run(self):
         """This is actually executed on calling start() and brings up the server"""
         if hasattr(self, "_server"):
-            print(
-                f"\n--------------------------------------------------------------\n"
-                f"|                                                            |\n"
-                f"| Your agent network is starting up. Open your browser and   |\n"
-                f"| visit the agentMET4FOF dashboard on "
-                f"http://{self.ip_addr}:{self.port}/ |\n"
-                f"|                                                            |\n"
-                f"--------------------------------------------------------------\n"
-            )
+            self._show_startup_message()
             self._server.serve_forever()
+
+    def _show_startup_message(self):
+        """This method prints the startup message of the webserver/dashboard"""
+        crucial_line = (
+            f"\n| visit the agentMET4FOF dashboard on http:/"
+            f"/{self.ip_addr}:{self.port}/ |"
+        )
+        crucial_line_len = len(crucial_line)
+
+        print(
+            f"\n|-".ljust(crucial_line_len - 1, "-"),
+            "|\n|".ljust(crucial_line_len, " "),
+            "|\n"
+            f"| Your agent network is starting up. Open your browser and".ljust(
+                crucial_line_len, " "
+            ),
+            "|",
+            crucial_line,
+            "\n|".ljust(crucial_line_len - 1, " "),
+            f"|"
+            f"\n|-".ljust(crucial_line_len, "-"),
+            "|\n",
+            sep="",
+        )
 
     def init_app_layout(self,update_interval_seconds=3, max_monitors=10,
                         dashboard_layouts=[],

--- a/agentMET4FOF/dashboard/Dashboard.py
+++ b/agentMET4FOF/dashboard/Dashboard.py
@@ -19,7 +19,7 @@ class AgentDashboard:
     An internal _Dashboard_Control object is instantiated inside this object, which manages access to the AgentNetwork.
     """
     def __init__(self, dashboard_modules=[], dashboard_layouts=[],
-                 dashboard_update_interval = 3, max_monitors=10, ip_addr="127.0.0.1",
+                 dashboard_update_interval = 3, max_monitors=10, ip_addr="0.0.0.0",
                  port=8050, agentNetwork="127.0.0.1", agent_ip_addr=3333,
                  agent_port=None, network_stylesheet=[], hide_default_edge=True, **kwargs):
         """


### PR DESCRIPTION
This should enable docker deployment without interfering with anything else up until now and thus resolves #254 . It is a huge step towards #215 .