### PR TITLE
Rename dashboard button to create downloadable image of agent network to "Export png"

### DIFF
--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -90,7 +90,7 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                                                     children=[
                                                         LayoutHelper.html_button(
                                                             icon="restore",
-                                                            text="Export JPG",
+                                                            text="Export png",
                                                             id="cyto-button-export",
                                                         )
                                                     ],


### PR DESCRIPTION
… because this is what happens.