### PR TITLE
Update deps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -269,7 +269,7 @@ pyrsistent==0.18.1
     # via
     #   -c requirements.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r dev-requirements.in
     #   pytest-cov
@@ -364,14 +364,13 @@ testpath==0.5.0
 tokenize-rt==4.2.1
     # via black
 toml==0.10.2
-    # via
-    #   pytest
-    #   tox
+    # via tox
 tomli==2.0.0
     # via
     #   -c requirements.txt
     #   black
     #   coverage
+    #   pytest
     #   setuptools-scm
 tomlkit==0.7.0
     # via python-semantic-release
@@ -403,7 +402,7 @@ urllib3==1.26.8
     #   -c requirements.txt
     #   requests
     #   twine
-virtualenv==20.13.0
+virtualenv==20.13.1
     # via tox
 wcwidth==0.2.5
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ networkx==2.6.3
     #   mesa
 notebook==6.4.8
     # via agentMET4FOF (setup.py)
-numpy==1.22.1
+numpy==1.22.2
     # via
     #   agentMET4FOF (setup.py)
     #   matplotlib
@@ -248,7 +248,7 @@ pyzmq==22.3.0
     #   osbrain
 requests==2.27.1
     # via cookiecutter
-scipy==1.7.3
+scipy==1.8.0
     # via
     #   agentMET4FOF (setup.py)
     #   pydynamic


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the commited deps       were succesfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.