### PR TITLE
Update deps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ attrs==21.4.0
     #   hypothesis
     #   jsonschema
     #   pytest
-babel==2.10.1
+babel==2.10.3
     # via sphinx
 backcall==0.2.0
     # via
@@ -26,22 +26,22 @@ beautifulsoup4==4.11.1
     # via
     #   -c requirements.txt
     #   nbconvert
-black[jupyter]==22.3.0
+black[jupyter]==22.6.0
     # via -r dev-requirements.in
-bleach==5.0.0
+bleach==5.0.1
     # via
     #   -c requirements.txt
     #   nbconvert
     #   readme-renderer
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -c requirements.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -c requirements.txt
     #   cryptography
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -c requirements.txt
     #   requests
@@ -53,11 +53,11 @@ click==8.1.3
     #   python-semantic-release
 click-log==0.4.0
     # via python-semantic-release
-colorama==0.4.4
+colorama==0.4.5
     # via twine
 commonmark==0.9.1
     # via recommonmark
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via pytest-cov
 cryptography==37.0.2
     # via secretstorage
@@ -85,6 +85,8 @@ entrypoints==0.4
     #   -c requirements.txt
     #   jupyter-client
     #   nbconvert
+exceptiongroup==1.0.0rc8
+    # via hypothesis
 executing==0.8.3
     # via
     #   -c requirements.txt
@@ -101,7 +103,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.46.9
+hypothesis==6.48.2
     # via -r dev-requirements.in
 idna==3.3
     # via
@@ -109,10 +111,8 @@ idna==3.3
     #   requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.4
-    # via
-    #   keyring
-    #   twine
+importlib-metadata==4.12.0
+    # via twine
 iniconfig==1.1.1
     # via pytest
 invoke==1.7.1
@@ -136,11 +136,11 @@ jinja2==3.1.2
     #   nbconvert
     #   nbsphinx
     #   sphinx
-jsonschema==4.5.1
+jsonschema==4.6.1
     # via
     #   -c requirements.txt
     #   nbformat
-jupyter-client==7.3.1
+jupyter-client==7.3.4
     # via
     #   -c requirements.txt
     #   nbclient
@@ -154,7 +154,7 @@ jupyterlab-pygments==0.2.2
     # via
     #   -c requirements.txt
     #   nbconvert
-keyring==23.5.1
+keyring==23.6.0
     # via twine
 markupsafe==2.1.1
     # via
@@ -171,7 +171,7 @@ mistune==0.8.4
     #   nbconvert
 mypy-extensions==0.4.3
     # via black
-nbclient==0.6.4
+nbclient==0.6.5
     # via
     #   -c requirements.txt
     #   nbconvert
@@ -185,7 +185,7 @@ nbformat==5.4.0
     #   nbclient
     #   nbconvert
     #   nbsphinx
-nbsphinx==0.8.8
+nbsphinx==0.8.9
     # via -r dev-requirements.in
 nest-asyncio==1.5.5
     # via
@@ -218,7 +218,7 @@ pickleshare==0.7.5
     # via
     #   -c requirements.txt
     #   ipython
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
     # via
@@ -228,7 +228,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -c requirements.txt
     #   ipython
@@ -280,15 +280,15 @@ python-dateutil==2.8.2
     # via
     #   -c requirements.txt
     #   jupyter-client
-python-gitlab==3.5.0
+python-gitlab==3.6.0
     # via python-semantic-release
-python-semantic-release==7.29.0
+python-semantic-release==7.29.4
     # via -r dev-requirements.in
 pytz==2022.1
     # via
     #   -c requirements.txt
     #   babel
-pyzmq==23.0.0
+pyzmq==23.2.0
     # via
     #   -c requirements.txt
     #   jupyter-client
@@ -296,7 +296,7 @@ readme-renderer==35.0
     # via twine
 recommonmark==0.7.1
     # via -r dev-requirements.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
@@ -315,7 +315,7 @@ secretstorage==3.3.2
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-setuptools-scm==6.4.2
+setuptools-scm==7.0.3
     # via dotty-dict
 six==1.16.0
     # via
@@ -335,7 +335,7 @@ soupsieve==2.3.2.post1
     # via
     #   -c requirements.txt
     #   beautifulsoup4
-sphinx==5.0.0
+sphinx==5.0.2
     # via
     #   -r dev-requirements.in
     #   nbsphinx
@@ -355,7 +355,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stack-data==0.2.0
+stack-data==0.3.0
     # via
     #   -c requirements.txt
     #   ipython
@@ -379,13 +379,13 @@ tornado==6.1
     # via
     #   -c requirements.txt
     #   jupyter-client
-tox==3.25.0
+tox==3.25.1
     # via -r dev-requirements.in
 tqdm==4.64.0
     # via
     #   -c requirements.txt
     #   twine
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   -c requirements.txt
     #   ipython
@@ -398,12 +398,14 @@ traitlets==5.2.2.post1
     #   nbsphinx
 twine==3.8.0
     # via python-semantic-release
+typing-extensions==4.2.0
+    # via setuptools-scm
 urllib3==1.26.9
     # via
     #   -c requirements.txt
     #   requests
     #   twine
-virtualenv==20.14.1
+virtualenv==20.15.1
     # via tox
 wcwidth==0.2.5
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,17 +20,17 @@ beautifulsoup4==4.11.1
     # via nbconvert
 binaryornot==0.4.4
     # via cookiecutter
-bleach==5.0.0
+bleach==5.0.1
     # via nbconvert
 brotli==1.0.9
     # via flask-compress
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via argon2-cffi-bindings
-chardet==4.0.0
+chardet==5.0.0
     # via binaryornot
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -39,11 +39,11 @@ click==8.1.3
     #   mesa
 cloudpickle==2.1.0
     # via osbrain
-cookiecutter==2.1.0
+cookiecutter==2.1.1
     # via mesa
 cycler==0.11.0
     # via matplotlib
-dash==2.4.1
+dash==2.5.1
     # via
     #   agentMET4FOF (setup.py)
     #   dash-cytoscape
@@ -83,7 +83,7 @@ future==0.18.2
     # via uncertainties
 idna==3.3
     # via requests
-ipykernel==6.13.0
+ipykernel==6.15.0
     # via notebook
 ipython==8.4.0
     # via ipykernel
@@ -103,9 +103,9 @@ jinja2==3.1.2
     #   notebook
 jinja2-time==0.2.0
     # via cookiecutter
-jsonschema==4.5.1
+jsonschema==4.6.1
     # via nbformat
-jupyter-client==7.3.1
+jupyter-client==7.3.4
     # via
     #   ipykernel
     #   nbclient
@@ -118,7 +118,7 @@ jupyter-core==4.10.0
     #   notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
-kiwisolver==1.4.2
+kiwisolver==1.4.3
     # via matplotlib
 markupsafe==2.1.1
     # via
@@ -143,7 +143,7 @@ mpmath==1.2.1
     # via sympy
 multiprocess==0.70.13
     # via agentMET4FOF (setup.py)
-nbclient==0.6.4
+nbclient==0.6.5
     # via nbconvert
 nbconvert==6.5.0
     # via notebook
@@ -158,13 +158,13 @@ nest-asyncio==1.5.5
     #   jupyter-client
     #   nbclient
     #   notebook
-networkx==2.8.2
+networkx==2.8.4
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
-notebook==6.4.11
+notebook==6.4.12
     # via agentMET4FOF (setup.py)
-numpy==1.22.4
+numpy==1.23.0
     # via
     #   agentMET4FOF (setup.py)
     #   matplotlib
@@ -180,7 +180,7 @@ packaging==21.3
     # via
     #   ipykernel
     #   nbconvert
-pandas==1.4.2
+pandas==1.4.3
     # via
     #   agentMET4FOF (setup.py)
     #   mesa
@@ -193,13 +193,13 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-plotly==5.8.0
+plotly==5.9.0
     # via
     #   agentMET4FOF (setup.py)
     #   dash
 prometheus-client==0.14.1
     # via notebook
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via ipython
 psutil==5.9.1
     # via ipykernel
@@ -239,12 +239,13 @@ pywavelets==1.3.0
     # via pydynamic
 pyyaml==6.0
     # via cookiecutter
-pyzmq==23.0.0
+pyzmq==23.2.0
     # via
+    #   ipykernel
     #   jupyter-client
     #   notebook
     #   osbrain
-requests==2.27.1
+requests==2.28.1
     # via cookiecutter
 scipy==1.8.1
     # via
@@ -252,7 +253,7 @@ scipy==1.8.1
     #   pydynamic
 send2trash==1.8.0
     # via notebook
-serpent==1.40
+serpent==1.41
     # via pyro4
 six==1.16.0
     # via
@@ -260,7 +261,7 @@ six==1.16.0
     #   python-dateutil
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-stack-data==0.2.0
+stack-data==0.3.0
     # via ipython
 sympy==1.10.1
     # via pydynamic
@@ -287,7 +288,7 @@ tornado==6.1
     #   terminado
 tqdm==4.64.0
     # via mesa
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   ipykernel
     #   ipython
@@ -298,7 +299,7 @@ traitlets==5.2.2.post1
     #   nbconvert
     #   nbformat
     #   notebook
-uncertainties==3.1.6
+uncertainties==3.1.7
     # via time-series-buffer
 urllib3==1.26.9
     # via requests


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the commited deps       were succesfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.