### PR TITLE
Remove CodeCov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,30 +150,11 @@ commands:
 
   run_venv_tests:
     description: "Run and store test results"
-    parameters:
-      send_cov:
-        type: boolean
-        default: false
     steps:
       - run:
           name: Run tests
           command: |
             tox | tee --append test-results/agentMET4FOF.log
-      - when:
-          condition: << parameters.send_cov >>
-          steps:
-            - run:
-                name: Upload coverage report
-                command: |
-                  curl -s https://codecov.io/bash > codecov;
-                  VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                  for i in 1 256 512
-                  do
-                    shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
-                    shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
-                  done
-                  chmod u+x codecov
-                  ./codecov
       - store_test_artifacts_and_results
 
   store_test_artifacts_and_results:
@@ -352,8 +333,7 @@ jobs:
           name: Install dependencies
           command: |
             pip install --upgrade tox
-      - run_venv_tests:
-          send_cov: true
+      - run_venv_tests
 
   test_against_venv:
     executor: tester

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ you have everything at your hands:
 
 ### Coding style
 
-As long as the readability of mathematical formulations is not impaired, our code shoulds
+As long as the readability of mathematical formulations is not impaired, our code should
 follow [PEP8](https://www.python.org/dev/peps/pep-0008/). We know we can improve on this
 requirement for the existing code base as well, but all code added should already
 conform to PEP8. For automating this uniform formatting task we use the Python package
@@ -125,13 +125,13 @@ needed starting from the third line. Each line should not exceed 100 characters.
 #### BREAKING CHANGEs
 
 Since agentMET4FOF is not yet considered stable, we do not mark BREAKING CHANGES. As a
-consequence, at any time commits may changes parts of agentMET4FOF's public interface so
+consequence, at any time commits may change parts of agentMET4FOF's public interface so
 that previously written code may no longer be executable. If this occurs we try though,
 to mention migration strategies in the corresponding release descriptions.
 
 #### Commit message examples
 
-For examples please checkout the
+For examples please check out the
 [Git Log](https://github.com/Met4FoF/agentMET4FOF/commits/develop).
 
 ###  Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,11 +136,11 @@ For examples please checkout the
 
 ###  Testing
 
-We strive to increase [our code coverage](https://codecov.io/gh/Met4FoF/agentMET4FOF)
-with every change introduced. This requires that every new feature and every change to 
-existing features is accompanied by appropriate _pytest_ testing. We test the basic
-components for correctness and, if necessary, the integration into the big picture.
-It is usually sufficient to create [appropriately named](https://docs.pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery)
+We strive to increase our code coverage with every change introduced. This requires 
+that every new feature and every change to existing features is accompanied by 
+appropriate _pytest_ testing. We test the basic components for correctness and, if 
+necessary, the integration into the big picture. It is usually sufficient to create 
+[appropriately named](https://docs.pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery)
 methods in one of the existing modules in the subfolder test. If necessary add a new
 module that is appropriately named.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
   <a href="https://agentmet4fof.readthedocs.io/">
     <img src="https://readthedocs.org/projects/agentmet4fof/badge/?version=latest" alt="ReadTheDocs badge">
   </a>
-  <!-- CodeCov(erage) -->
-  <a href="https://codecov.io/gh/Met4FoF/agentMET4FOF">
-    <img src="https://codecov.io/gh/Met4FoF/agentMET4FOF/branch/develop/graph/badge.svg?token=ofAPdSudLy" alt="CodeCov badge"/>
-  </a>
   <!-- PyPI Version -->
   <a href="https://pypi.org/project/agentmet4fof">
     <img src="https://img.shields.io/pypi/v/agentmet4fof.svg?label=release&color=blue&style=flat-square" alt="pypi">


### PR DESCRIPTION
... is it adds another layer of complexity to the pipeline and it is not really needed as of now. Noone noticed for three years that the coverage was not updated due to an unnoticed error in the mechanism.